### PR TITLE
feat(web): add placeholder chat route

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,12 +14,19 @@ import type { CreateFileRoute, FileRoutesByPath } from '@tanstack/react-router'
 
 import { Route as rootRoute } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ChatChatIdRouteImport } from './routes/chat/$chatId'
 
 // Create/Update Routes
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const ChatChatIdRoute = ChatChatIdRouteImport.update({
+  id: '/chat/$chatId',
+  path: '/chat/$chatId',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -32,6 +39,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRoute
+    }
+    '/chat/$chatId': {
+      id: '/chat/$chatId'
+      path: '/chat/$chatId'
+      fullPath: '/chat/$chatId'
+      preLoaderRoute: typeof ChatChatIdRouteImport
       parentRoute: typeof rootRoute
     }
   }
@@ -48,37 +62,51 @@ declare module './routes/index' {
     FileRoutesByPath['/']['fullPath']
   >
 }
+declare module './routes/chat/$chatId' {
+  const createFileRoute: CreateFileRoute<
+    '/chat/$chatId',
+    FileRoutesByPath['/chat/$chatId']['parentRoute'],
+    FileRoutesByPath['/chat/$chatId']['id'],
+    FileRoutesByPath['/chat/$chatId']['path'],
+    FileRoutesByPath['/chat/$chatId']['fullPath']
+  >
+}
 
 // Create and export the route tree
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/chat/$chatId': typeof ChatChatIdRoute
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/chat/$chatId': typeof ChatChatIdRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
+  '/chat/$chatId': typeof ChatChatIdRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/chat/$chatId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/chat/$chatId'
+  id: '__root__' | '/' | '/chat/$chatId'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ChatChatIdRoute: typeof ChatChatIdRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ChatChatIdRoute: ChatChatIdRoute,
 }
 
 export const routeTree = rootRoute
@@ -91,11 +119,15 @@ export const routeTree = rootRoute
     "__root__": {
       "filePath": "__root.tsx",
       "children": [
-        "/"
+        "/",
+        "/chat/$chatId"
       ]
     },
     "/": {
       "filePath": "index.tsx"
+    },
+    "/chat/$chatId": {
+      "filePath": "chat/$chatId.tsx"
     }
   }
 }

--- a/apps/web/src/routes/chat/$chatId.tsx
+++ b/apps/web/src/routes/chat/$chatId.tsx
@@ -1,0 +1,15 @@
+export const Route = createFileRoute({
+  loader: async ({ params }) => {
+    console.log(params.chatId);
+    return {
+      chatId: params.chatId,
+    };
+  },
+  component: Chat,
+});
+
+function Chat() {
+  const { chatId } = Route.useParams();
+
+  return <div>Chat {chatId}</div>;
+}


### PR DESCRIPTION
### TL;DR

Added a new chat route with dynamic chat ID parameter.

### What changed?

- Created a new route at `/chat/$chatId` that accepts a dynamic chat ID parameter
- Added a new component file `chat/$chatId.tsx` with a basic Chat component
- Updated the route tree to include the new chat route
- Implemented a loader function that logs and returns the chat ID parameter

### How to test?

1. Navigate to `/chat/[any-id]` where `[any-id]` is any string value
2. Verify that the page displays "Chat [any-id]"
3. Check the console logs to ensure the chat ID parameter is being logged correctly

### Why make this change?

This change establishes the foundation for individual chat pages, allowing users to access specific chat conversations via unique IDs. This is a necessary step for implementing chat functionality in the application.