### PR TITLE
feat(web): add queries for chat and index fields

### DIFF
--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as betterAuth from "../betterAuth.js";
+import type * as functions_chat from "../functions/chat.js";
 import type * as message from "../message.js";
 
 /**
@@ -26,6 +27,7 @@ import type * as message from "../message.js";
  */
 declare const fullApi: ApiFromModules<{
   betterAuth: typeof betterAuth;
+  "functions/chat": typeof functions_chat;
   message: typeof message;
 }>;
 export declare const api: FilterApi<

--- a/apps/web/convex/functions/chat.ts
+++ b/apps/web/convex/functions/chat.ts
@@ -1,0 +1,27 @@
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { query } from "../_generated/server";
+import { v } from "convex/values";
+
+export const getUserChats = query({
+  args: { sessionToken: v.string() },
+  handler: async (ctx, args) => {
+    const session = await ctx.runQuery(internal.betterAuth.getSession, {
+      sessionToken: args.sessionToken,
+    });
+
+    if (!session) {
+      throw new Error("Unauthorized");
+    }
+
+    const userId = session.userId as Id<"user">;
+
+    const chats = await ctx.db
+      .query("chat")
+      .filter((q) => q.eq(q.field("ownerId"), userId))
+      .order("desc")
+      .collect();
+
+    return chats;
+  },
+});

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -12,9 +12,9 @@ export default defineSchema({
     ownerId: v.id("user"),
     // Whether the chat is shared/public
     visibility: v.union(
-      v.literal("private"),    // only owner + invited members
-      v.literal("shared"),     // anyone with link
-      v.literal("public"),     // discoverable/searchable
+      v.literal("private"), // only owner + invited members
+      v.literal("shared"), // anyone with link
+      v.literal("public") // discoverable/searchable
     ),
     // Token for sharing the chat
     shareToken: v.optional(v.string()),
@@ -22,7 +22,9 @@ export default defineSchema({
     provider: v.optional(v.string()),
     // Last update timestamp
     updatedAt: v.string(),
-  }),
+  })
+    .index("by_ownerId", ["ownerId"])
+    .index("by_visibility", ["visibility"]),
 
   // Many-to-many relationship: users in a chat
   chatMember: defineTable({
@@ -70,7 +72,7 @@ export default defineSchema({
         promptTokens: v.number(),
         completionTokens: v.number(),
         totalTokens: v.number(),
-      }),
+      })
     ),
     toolCalls: v.optional(v.array(v.any())),
     citations: v.optional(v.array(v.any())),
@@ -100,8 +102,8 @@ export default defineSchema({
           citations: v.optional(v.array(v.any())),
           // When this attempt was created
           createdAt: v.string(),
-        }),
-      ),
+        })
+      )
     ),
 
     // Web search/RAG results (if any)
@@ -149,13 +151,13 @@ export default defineSchema({
             promptTokens: v.number(),
             completionTokens: v.number(),
             totalTokens: v.number(),
-          }),
+          })
         ),
         // When this version was created
         createdAt: v.string(),
         // Optional reason for the change (e.g., "user_retry", "initial_generation")
         reason: v.optional(v.string()),
-      }),
+      })
     ),
     // Order/index among siblings
     order: v.number(),


### PR DESCRIPTION
### TL;DR

Added a new query function to retrieve user chats and added indexes to the chat table for improved query performance.

### What changed?

- Created a new `getUserChats` query function in `functions/chat.ts` that retrieves all chats owned by a user
- Added two indexes to the `chat` table in the schema:
  - `by_ownerId` index on the `ownerId` field
  - `by_visibility` index on the `visibility` field
- Updated the generated API types to include the new chat functions

### How to test?

1. Call the `getUserChats` query with a valid session token
2. Verify that it returns all chats owned by the authenticated user
3. Check that the chats are ordered by descending order
4. Verify that unauthorized requests throw an "Unauthorized" error

### Why make this change?

This change enables efficient retrieval of a user's chats, which is a fundamental feature for the chat application. The added indexes improve query performance when filtering chats by owner or visibility status, which will be important for scaling as the number of chats grows.