### PR TITLE
feat(web): add redirect and chatId creation for new chats

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,8 @@
     "react-dom": "19.1.0",
     "tailwind-merge": "3.3.0",
     "vite": "6.3.5",
-    "zod": "^3.25.56"
+    "zod": "^3.25.56",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@tailwindcss/vite": "4.1.8",

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -43,7 +43,7 @@ export function AppSidebar() {
                       to="/chat/$chatId"
                       params={{ chatId: chat._id }}
                     >
-                      {chat.description}
+                      {chat.title}
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>

--- a/apps/web/src/components/chatView.tsx
+++ b/apps/web/src/components/chatView.tsx
@@ -1,0 +1,96 @@
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useChat } from "@ai-sdk/react";
+import { isRedirect } from "@tanstack/react-router";
+import { useMutation } from "convex/react";
+import { authClient } from "~/lib/auth/client";
+import { api } from "../../convex/_generated/api";
+import { useMessageStore } from "~/stores/message-store";
+import { useEffect } from "react";
+
+export function ChatView() {
+  const { data: session } = authClient.useSession();
+  const createChat = useMutation(api.functions.chat.createChat);
+  const {
+    firstMessage,
+    hasBeenSent,
+    setFirstMessage,
+    markAsSent,
+    clearFirstMessage,
+  } = useMessageStore();
+  const navigate = useNavigate();
+
+  const params = useParams({ strict: false }) as { chatId?: string };
+  const chatId = params?.chatId;
+
+  const { input, handleInputChange, append, messages, status } = useChat({
+    id: chatId ?? "skip",
+    body: { chatId },
+  });
+
+  useEffect(() => {
+    if (chatId && firstMessage && !hasBeenSent) {
+      append({ role: "user", content: firstMessage });
+      clearFirstMessage();
+      markAsSent();
+    }
+  }, [
+    chatId,
+    firstMessage,
+    hasBeenSent,
+    append,
+    markAsSent,
+    clearFirstMessage,
+  ]);
+
+  async function send() {
+    const text = input.trim();
+    if (!text) return;
+
+    if (!chatId) {
+      try {
+        setFirstMessage(text);
+
+        const newChatId = await createChat({
+          sessionToken: session?.session.token ?? "skip",
+          title: "New Chat",
+          visibility: "private",
+        });
+
+        console.log("[ChatView] New Chat ID: ", newChatId);
+
+        navigate({
+          to: "/chat/$chatId",
+          replace: true,
+          params: { chatId: newChatId },
+        });
+      } catch (err) {
+        if (!isRedirect(err)) throw err;
+      }
+      return;
+    }
+
+    await append({ role: "user", content: text });
+  }
+
+  return (
+    <>
+      {messages.map((m) => (
+        <div key={m.id}>
+          {m.role}: {m.content}
+        </div>
+      ))}
+
+      <input
+        className="bg-black text-white"
+        value={input}
+        onChange={handleInputChange}
+      />
+      <button
+        disabled={status === "submitted" || status === "streaming"}
+        onClick={send}
+      >
+        Send
+      </button>
+    </>
+  );
+}

--- a/apps/web/src/routes/chat/$chatId.tsx
+++ b/apps/web/src/routes/chat/$chatId.tsx
@@ -1,15 +1,5 @@
+import { ChatView } from "~/components/chatView";
+
 export const Route = createFileRoute({
-  loader: async ({ params }) => {
-    console.log(params.chatId);
-    return {
-      chatId: params.chatId,
-    };
-  },
-  component: Chat,
+  component: ChatView,
 });
-
-function Chat() {
-  const { chatId } = Route.useParams();
-
-  return <div>Chat {chatId}</div>;
-}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { useChat } from "@ai-sdk/react";
+import { ChatView } from "~/components/chatView";
 
 // TODO: fix this poop
 
@@ -35,64 +36,64 @@ const PlusSVG = () => (
 );
 
 export const Route = createFileRoute({
-  component: Index,
+  component: ChatView,
 });
 
-function Index() {
-  const { messages, input, handleInputChange, handleSubmit } = useChat({
-    api: "/api/chat",
-  });
+// function Index() {
+//   const { messages, input, handleInputChange, handleSubmit } = useChat({
+//     api: "/api/chat",
+//   });
 
-  return (
-    <div className="mx-auto h-full w-full overscroll-none md:w-1/2">
-      <div className="mx-auto flex w-[94%] flex-col gap-y-4 pt-4 pb-36 items-center justify-center">
-        <div className="w-full max-w-md space-y-4">
-          {messages.map((message) => (
-            <div
-              key={message.id}
-              className={`whitespace-pre-wrap p-4 border-2 border-dotted border-gray-700 bg-white ${
-                message.role === "user"
-                  ? "ml-auto max-w-[80%]"
-                  : "mr-auto max-w-[80%]"
-              }`}
-            >
-              {message.parts.map((part, i) => {
-                switch (part.type) {
-                  case "text":
-                    return (
-                      <div key={`${message.id}-${i}`} className="text-gray-900">
-                        {part.text}
-                      </div>
-                    );
-                  default:
-                    return null;
-                }
-              })}
-            </div>
-          ))}
-        </div>
-      </div>
+//   return (
+//     <div className="mx-auto h-full w-full overscroll-none md:w-1/2">
+//       <div className="mx-auto flex w-[94%] flex-col gap-y-4 pt-4 pb-36 items-center justify-center">
+//         <div className="w-full max-w-md space-y-4">
+//           {messages.map((message) => (
+//             <div
+//               key={message.id}
+//               className={`whitespace-pre-wrap p-4 border-2 border-dotted border-gray-700 bg-white ${
+//                 message.role === "user"
+//                   ? "ml-auto max-w-[80%]"
+//                   : "mr-auto max-w-[80%]"
+//               }`}
+//             >
+//               {message.parts.map((part, i) => {
+//                 switch (part.type) {
+//                   case "text":
+//                     return (
+//                       <div key={`${message.id}-${i}`} className="text-gray-900">
+//                         {part.text}
+//                       </div>
+//                     );
+//                   default:
+//                     return null;
+//                 }
+//               })}
+//             </div>
+//           ))}
+//         </div>
+//       </div>
 
-      <div className="group fixed bottom-0 w-full md:w-1/2 px-2">
-        <form onSubmit={handleSubmit}>
-          <div className="relative w-full max-w-md mx-auto border-t-2 border-x-2 border-dotted border-gray-700 bg-white">
-            <span className="absolute top-0 left-0 -translate-x-1/2 -translate-y-1/2 select-none">
-              <PlusSVG />
-            </span>
-            <span className="absolute top-0 right-0 translate-x-1/2 -translate-y-1/2 select-none">
-              <PlusSVG />
-            </span>
-            <input
-              type="text"
-              value={input}
-              onChange={handleInputChange}
-              placeholder="Type your message..."
-              className="w-full bg-transparent outline-none px-4 py-3 text-gray-900 placeholder-gray-400 rounded-lg"
-              aria-label="Chat message input"
-            />
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
+//       <div className="group fixed bottom-0 w-full md:w-1/2 px-2">
+//         <form onSubmit={handleSubmit}>
+//           <div className="relative w-full max-w-md mx-auto border-t-2 border-x-2 border-dotted border-gray-700 bg-white">
+//             <span className="absolute top-0 left-0 -translate-x-1/2 -translate-y-1/2 select-none">
+//               <PlusSVG />
+//             </span>
+//             <span className="absolute top-0 right-0 translate-x-1/2 -translate-y-1/2 select-none">
+//               <PlusSVG />
+//             </span>
+//             <input
+//               type="text"
+//               value={input}
+//               onChange={handleInputChange}
+//               placeholder="Type your message..."
+//               className="w-full bg-transparent outline-none px-4 py-3 text-gray-900 placeholder-gray-400 rounded-lg"
+//               aria-label="Chat message input"
+//             />
+//           </div>
+//         </form>
+//       </div>
+//     </div>
+//   );
+// }

--- a/apps/web/src/stores/message-store.ts
+++ b/apps/web/src/stores/message-store.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+interface MessageStore {
+  firstMessage: string | null;
+  hasBeenSent: boolean;
+  setFirstMessage: (message: string) => void;
+  markAsSent: () => void;
+  clearFirstMessage: () => void;
+}
+
+export const useMessageStore = create<MessageStore>((set) => ({
+  firstMessage: null,
+  hasBeenSent: false,
+  setFirstMessage: (message: string) =>
+    set({ firstMessage: message, hasBeenSent: false }),
+  markAsSent: () => set({ hasBeenSent: true }),
+  clearFirstMessage: () => set({ firstMessage: null, hasBeenSent: false }),
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       zod:
         specifier: ^3.25.56
         version: 3.25.56
+      zustand:
+        specifier: ^5.0.5
+        version: 5.0.5(@types/react@19.1.6)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
       '@tailwindcss/vite':
         specifier: 4.1.8
@@ -4002,6 +4005,24 @@ packages:
 
   zod@3.25.56:
     resolution: {integrity: sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==}
+
+  zustand@5.0.5:
+    resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -7974,3 +7995,9 @@ snapshots:
       zod: 3.25.56
 
   zod@3.25.56: {}
+
+  zustand@5.0.5(@types/react@19.1.6)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
+    optionalDependencies:
+      '@types/react': 19.1.6
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)


### PR DESCRIPTION
# Implement Chat Functionality with Authentication

### TL;DR
Added chat creation and messaging functionality with proper authentication and session management.

### What changed?
- Modified `createChat` mutation to use session tokens for authentication instead of directly passing user IDs
- Created a reusable `ChatView` component that handles both new and existing chats
- Added message persistence with Zustand store to handle message state across navigation
- Updated routes to use the new ChatView component
- Fixed sidebar to display chat titles instead of descriptions

### How to test?
1. Start a new chat from the home page
2. Type a message and send it
3. Verify the chat is created and the message appears
4. Navigate to an existing chat via the sidebar
5. Verify messages are displayed correctly

### Why make this change?
This change improves security by properly authenticating users through session tokens rather than directly passing user IDs. It also creates a unified chat interface that works for both new and existing conversations, with proper state management to maintain messages during navigation.