### PR TITLE
feat(web): clean up ui

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -31,6 +31,9 @@ export function AppSidebar() {
 
   return (
     <Sidebar>
+      <div className="p-4">
+        <h1 className="text-lg font-semibold text-center">OpenYap</h1>
+      </div>
       <SidebarHeader />
       <SidebarContent>
         <SidebarGroup>
@@ -48,8 +51,8 @@ export function AppSidebar() {
                       key={chat._id}
                       to="/chat/$chatId"
                       params={{ chatId: chat._id }}
-                  >
-                      {chat.title}
+                    >
+                      <span className="block truncate max-w-full">{chat.title}</span>
                     </Link>
                   </SidebarMenuButton>
                   <SidebarMenuAction

--- a/apps/web/src/components/auth/profile-card.tsx
+++ b/apps/web/src/components/auth/profile-card.tsx
@@ -1,3 +1,4 @@
+import { LogOutIcon } from "lucide-react";
 import { useState } from "react";
 import { useTransition } from "react";
 import { CaptchaWidget } from "~/components/auth/captcha-widget";
@@ -39,24 +40,29 @@ export function ProfileCard() {
   };
 
   if (session.isPending) {
-    return <div>Loading...</div>;
+    return (
+      <div className="h-12 animate-pulse bg-gray-200 flex items-center justify-center rounded">
+      </div>
+    );
   }
 
   if (session.data?.user) {
     return (
-        <div>
+        <div className="h-12 flex items-center justify-between border border-gray-200 rounded px-2">
           <p>{session.data.user.name}</p>
-          <Button onClick={() => authClient.signOut()}>Sign out</Button>
+          <Button onClick={() => authClient.signOut()} className="hover:bg-gray-200">
+            <LogOutIcon className="w-4 h-4" />
+          </Button>
         </div>
       );
   }
 
   return (
-    <div>
+    <div className="h-12 flex items-center justify-center border border-gray-200 rounded">
       <Button
         type="button"
         onClick={handleGoogleLogin}
-        className="w-full bg-white text-gray-900 border border-gray-200 hover:bg-gray-50"
+        className="h-full w-full bg-white text-gray-900 hover:bg-gray-50"
         disabled={isPending}
       >
         <DomainLogo domain="google.com" />

--- a/apps/web/src/components/chat-view.tsx
+++ b/apps/web/src/components/chat-view.tsx
@@ -4,8 +4,9 @@ import { isRedirect } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { authClient } from "~/lib/auth/client";
 import { api } from "~/lib/db/server";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { Id } from "convex/_generated/dataModel";
+import { ArrowUpIcon } from "lucide-react";
 
 export function ChatView() {
   const { data: session } = authClient.useSession();
@@ -21,15 +22,12 @@ export function ChatView() {
       : "skip"
   );
   const navigate = useNavigate();
-
+  const [input, setInput] = useState("");
 
   const { 
-    input, 
     messages, 
     status, 
-    handleInputChange, 
     append, 
-    setInput,
   } =
     useChat({
       id: chatId ?? "skip",
@@ -63,6 +61,10 @@ export function ChatView() {
     }
     sendFirstMessage();
   }, [chatId, append, session?.session.token, updateChat]);
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setInput(e.target.value);
+  }
 
   async function send() {
     const text = input.trim();
@@ -99,7 +101,7 @@ export function ChatView() {
     <div className="flex flex-col h-full bg-white">
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.length === 0 ? (
-          <div className="flex items-center justify-center h-full text-gray-500">
+          <div className="flex items-center justify-center h-full text-black">
             <p>Start a conversation...</p>
           </div>
         ) : (
@@ -111,10 +113,10 @@ export function ChatView() {
               }`}
             >
               <div
-                className={`max-w-[70%] rounded-lg px-4 py-2 ${
+                className={`max-w-[70%] rounded-lg px-4 py-2 border ${
                   m.role === "user"
-                    ? "bg-blue-500 text-white ml-auto"
-                    : "bg-gray-100 text-gray-900 mr-auto"
+                    ? "bg-white text-black border-black ml-auto"
+                    : "bg-black text-white border-black mr-auto"
                 }`}
               >
                 <p className="whitespace-pre-wrap break-words">{m.content}</p>
@@ -124,11 +126,11 @@ export function ChatView() {
         )}
         {status === "streaming" && (
           <div className="flex justify-start">
-            <div className="bg-gray-100 text-gray-900 rounded-lg px-4 py-2 max-w-[70%]">
+            <div className="bg-white text-black rounded-lg px-4 py-2 max-w-[70%] border border-black">
               <div className="flex items-center space-x-1">
-                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" />
-                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce delay-100" />
-                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce delay-200" />
+                <div className="w-2 h-2 bg-black rounded-full animate-bounce" />
+                <div className="w-2 h-2 bg-black rounded-full animate-bounce delay-100" />
+                <div className="w-2 h-2 bg-black rounded-full animate-bounce delay-200" />
               </div>
             </div>
           </div>
@@ -136,10 +138,10 @@ export function ChatView() {
       </div>
 
       {/* Input Area */}
-      <div className="border-t border-gray-200 p-4 bg-white">
-        <div className="flex items-center space-x-2 max-w-4xl mx-auto">
+      <div className="border-t border-black p-4 bg-white">
+        <div className="flex items-center space-x-2 max-w-4xl mx-auto border border-black rounded-lg p-2">
           <input
-            className="flex-1 border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100 disabled:cursor-not-allowed"
+            className="flex-1 p-2 bg-white text-black placeholder:text-gray-400 focus:outline-none disabled:bg-white disabled:text-gray-500 disabled:cursor-not-allowed"
             placeholder="Type your message..."
             value={input}
             onChange={handleInputChange}
@@ -157,16 +159,16 @@ export function ChatView() {
               status === "submitted" || status === "streaming" || !input.trim()
             }
             onClick={send}
-            className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+            className={`px-4 py-2 rounded-lg font-medium transition-colors border border-black text-black bg-white disabled:bg-white disabled:text-gray-500 disabled:border-gray-300 ${
               status === "submitted" || status === "streaming" || !input.trim()
-                ? "bg-gray-300 text-gray-500 cursor-not-allowed"
-                : "bg-blue-500 text-white hover:bg-blue-600"
+                ? "cursor-not-allowed"
+                : "hover:bg-black hover:text-white"
             }`}
           >
             {status === "submitted" || status === "streaming" ? (
-              <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              <div className="w-4 h-4 border-2 border-black border-t-transparent rounded-full animate-spin" />
             ) : (
-              "Send"
+              <ArrowUpIcon className="w-4 h-4" />
             )}
           </button>
         </div>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -61,12 +61,11 @@ function RootDocument({ children }: { readonly children: React.ReactNode }) {
       </head>
       <body>
         <SidebarProvider>
+          <div className="fixed top-0 left-0 z-50 p-4">
+            <SidebarTrigger />
+          </div>
           <AppSidebar />
           <SidebarInset>
-            <div className="flex items-center gap-2 p-4 border-b">
-              <SidebarTrigger />
-              <h1 className="text-lg font-semibold">OpenYap</h1>
-            </div>
             {children}
           </SidebarInset>
         </SidebarProvider>


### PR DESCRIPTION
### TL;DR

Redesigned the UI with a minimalist black and white theme, improved chat layout, and enhanced user experience elements.

### What changed?

- Added "OpenYap" title to the sidebar header
- Improved chat title truncation in the sidebar
- Enhanced profile card with loading state and better styling
- Redesigned chat interface with black and white theme:
  - Changed message bubbles to black/white with borders
  - Updated input area with cleaner design
  - Replaced "Send" button with an arrow icon
  - Improved loading/typing indicators
- Relocated the sidebar trigger to the top-left corner
- Fixed chat input handling by moving state management

### How to test?

1. Check the new sidebar with the OpenYap title
2. Verify long chat titles properly truncate in the sidebar
3. Test the profile card in different states (loading, signed in, signed out)
4. Send messages in the chat to see the new message bubble design
5. Observe the typing indicators and loading states
6. Verify the sidebar trigger works from its new position
7. Test chat functionality to ensure input and sending still work properly

### Why make this change?

This redesign creates a more cohesive, minimalist aesthetic with a black and white color scheme that improves readability and visual hierarchy. The layout changes enhance usability by making navigation more intuitive and ensuring content displays properly (like truncating long chat titles). The improved loading states and animations provide better feedback to users during interactions.