### PR TITLE
feat(web): update UI with light theme and add link block component

### DIFF
--- a/apps/web/src/components/blocks.tsx
+++ b/apps/web/src/components/blocks.tsx
@@ -1,7 +1,7 @@
 import type { Token } from "marked";
 import { useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { oneLight } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { cn } from "~/lib/utils";
 
 function randomKey() {
@@ -92,8 +92,12 @@ export function TokenBlock({ token }: TokenBlockProps) {
     return <HeadingBlock key={randomKey()} text={token.text} />;
   }
 
+  if (token.type === "link") {
+    return <LinkBlock key={randomKey()} text={token.text} href={token.href} />;
+  }
+
   return (
-    <span key={randomKey()} className="text-gray-800 text-sm">
+    <span key={randomKey()} className="text-gray-800 text-base">
       {token.raw}
     </span>
   );
@@ -107,7 +111,7 @@ type StrongBlockProps = {
 function StrongBlock({ tokens, text }: StrongBlockProps) {
   if (!tokens) {
     return (
-      <strong key={randomKey()} className="text-gray-900 text-sm">
+      <strong key={randomKey()} className="text-gray-900 text-base">
         {text}
       </strong>
     );
@@ -130,7 +134,7 @@ type TextBlockProps = {
 function TextBlock({ tokens, text }: TextBlockProps) {
   if (!tokens) {
     return (
-      <span key={randomKey()} className="text-gray-800 text-sm">
+      <span key={randomKey()} className="text-gray-800 text-base">
         {text}
       </span>
     );
@@ -171,7 +175,7 @@ function CodeBlock({ lang, text }: CodeBlockProps) {
               className={`${langIcon(highlightedLang)} h-4 w-4 text-gray-400`}
             />
           )}
-          <span className="text-gray-500 text-xs">{highlightedLang}</span>
+          <span className="text-gray-500 text-sm">{highlightedLang}</span>
         </div>
         <button
           type="button"
@@ -183,13 +187,17 @@ function CodeBlock({ lang, text }: CodeBlockProps) {
               "iconify h-4 w-4",
               isChecked
                 ? "lucide--check text-green-500"
-                : "lucide--copy text-gray-400",
+                : "lucide--copy text-gray-400"
             )}
           />
         </button>
       </div>
       <pre className="*:!m-0 bg-white">
-        <SyntaxHighlighter language={highlightedLang} style={vscDarkPlus} customStyle={{ background: 'white', color: '#111827' }}>
+        <SyntaxHighlighter
+          language={highlightedLang}
+          style={oneLight}
+          customStyle={{ color: "#111827", fontSize: "14px" }}
+        >
           {text}
         </SyntaxHighlighter>
       </pre>
@@ -210,7 +218,7 @@ function CodeSpanBlock({ text }: CodeSpanBlockProps) {
     <code
       key={randomKey()}
       onMouseDown={copyText}
-      className="cursor-pointer rounded bg-gray-100 px-1 py-[0.5px] text-gray-800 text-sm"
+      className="cursor-pointer rounded bg-gray-100 px-1 py-[0.5px] text-gray-800 text-base"
     >
       {text}
     </code>
@@ -226,7 +234,7 @@ function ParagraphBlock({ tokens, text }: ParagraphBlockProps) {
   if (!tokens) {
     return (
       <p key={randomKey()}>
-        <span className="text-gray-800 text-sm">{text}</span>
+        <span className="text-gray-800 text-base">{text}</span>
       </p>
     );
   }
@@ -249,7 +257,7 @@ function ListItemBlock({ tokens, number }: ListItemBlockProps) {
   return (
     <li key={randomKey()}>
       {number && (
-        <span className="pr-1 text-gray-500 text-sm">{number}.</span>
+        <span className="pr-1 text-gray-500 text-base">{number}.</span>
       )}
       {tokens.map((token) => {
         return <TokenBlock key={randomKey()} token={token} />;
@@ -294,7 +302,7 @@ function ListBlock({ items, ordered, start }: ListBlockProps) {
   }
 
   return (
-    <ul key={randomKey()} className="list-disc pl-3 text-gray-500 text-sm">
+    <ul key={randomKey()} className="list-disc pl-3 text-gray-500 text-base">
       {items.map((item) => {
         return <ListItemBlock key={randomKey()} tokens={item.tokens} />;
       })}
@@ -314,5 +322,24 @@ function HeadingBlock({ text }: HeadingBlockProps) {
     >
       {text}
     </h3>
+  );
+}
+
+type LinkBlockProps = {
+  text: string;
+  href: string;
+};
+
+function LinkBlock({ text, href }: LinkBlockProps) {
+  return (
+    <a
+      key={randomKey()}
+      href={href}
+      className="text-blue-500 hover:underline after:content-['↗'] after:ml-1"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {text}
+    </a>
   );
 }

--- a/apps/web/src/components/chat-view.tsx
+++ b/apps/web/src/components/chat-view.tsx
@@ -8,6 +8,8 @@ import { useEffect, useState } from "react";
 import type { Id } from "convex/_generated/dataModel";
 import { ArrowUpIcon } from "lucide-react";
 import { Message } from "~/components/message";
+import { Input } from "./ui/input";
+import { Button } from "./ui/button";
 
 interface ChatInputProps {
   chatId?: string;
@@ -62,11 +64,11 @@ function ChatInput({
   }
 
   return (
-    <div className="border-t border-black p-4 bg-white">
-      <div className="flex items-center space-x-2 max-w-4xl mx-auto border border-black rounded-lg p-2">
-        <input
-          className="flex-1 p-2 bg-white text-black placeholder:text-gray-400 focus:outline-none disabled:bg-white disabled:text-gray-500 disabled:cursor-not-allowed"
-          placeholder="Type your message..."
+    <div className="sticky bottom-0 pb-4 z-10 bg-background">
+      <div className="flex gap-2 max-w-5xl mx-auto w-full h-10">
+        <Input
+          className="bg-background h-full"
+          placeholder="Yap, yap, yap..."
           value={input}
           onChange={handleInputChange}
           disabled={disabled}
@@ -77,22 +79,18 @@ function ChatInput({
             }
           }}
         />
-        <button
+        <Button
           type="button"
           disabled={disabled || !input.trim()}
           onClick={send}
-          className={`px-4 py-2 rounded-lg font-medium transition-colors border border-black text-black bg-white disabled:bg-white disabled:text-gray-500 disabled:border-gray-300 ${
-            disabled || !input.trim()
-              ? "cursor-not-allowed"
-              : "hover:bg-black hover:text-white"
-          }`}
+          className={`${disabled || (!input.trim() && "cursor-not-allowed")} h-full w-10`}
         >
           {disabled ? (
             <div className="w-4 h-4 border-2 border-black border-t-transparent rounded-full animate-spin" />
           ) : (
             <ArrowUpIcon className="w-4 h-4" />
           )}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -150,10 +148,10 @@ export function ChatView() {
   return (
     <div className="flex flex-col h-full bg-background">
       <div className="flex-1 overflow-y-auto p-4">
-        <div className="max-w-4xl mx-auto space-y-4">
+        <div className="max-w-4xl mx-auto space-y-4 h-full">
           {messages.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-foreground">
-              <p>Start a conversation...</p>
+            <div className="flex items-center justify-center text-foreground h-full">
+              <h1 className="text-2xl">Where should we begin?</h1>
             </div>
           ) : (
             messages.map((m) => (


### PR DESCRIPTION
### TL;DR

Updated the chat UI with a cleaner design, improved typography, and added support for link rendering in markdown.

### What changed?

- Switched syntax highlighting theme from `vscDarkPlus` to `oneLight` for better readability
- Increased text size from `text-sm` to `text-base` across various text components
- Added a new `LinkBlock` component to properly render links with an external link indicator
- Redesigned the chat input area with a cleaner, more modern look using the UI components
- Updated the empty state message to "Where should we begin?" for a more inviting experience
- Made the chat input sticky to the bottom of the viewport for better usability
- Added custom styling for code blocks with improved font size

### How to test?

1. Open the chat interface and verify the new styling looks correct
2. Test sending messages with markdown links to ensure they render properly with the external link indicator
3. Check that code blocks use the new light theme and have the correct font size
4. Verify the chat input stays at the bottom of the screen when scrolling
5. Clear the chat and confirm the empty state displays the new message

### Why make this change?

This update improves readability and user experience by using more appropriate text sizes and a lighter syntax highlighting theme. The addition of proper link rendering enhances the functionality of markdown messages, while the redesigned chat input provides a more modern and intuitive interface. These changes collectively create a more polished and user-friendly chat experience.