### PR TITLE
feat(web): fix sidebar styling and chat padding

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -6,7 +6,6 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -52,7 +51,6 @@ export function AppSidebar() {
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
-        <SidebarSeparator />
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
@@ -75,25 +73,22 @@ export function AppSidebar() {
                   <SidebarMenuAction
                     showOnHover
                     asChild
-                    className="top-1/2 -translate-y-1/4"
-                  >
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      tabIndex={-1}
-                      aria-label="Delete chat"
-                      onClick={async (e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        await deleteChat({
-                          chatId: chat._id,
-                          sessionToken: session?.session.token ?? "",
-                        });
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      await deleteChat({
+                        chatId: chat._id,
+                        sessionToken: session?.session.token ?? "",
+                      });
+                      if (params.chatId === chat._id) {
                         navigate({ to: "/" });
-                      }}
-                    >
+                      }
+                    }}
+                    className="hover:cursor-pointerdd"
+                  >
+                    <div>
                       <X className="size-4" />
-                    </Button>
+                    </div>
                   </SidebarMenuAction>
                 </SidebarMenuItem>
               ))}

--- a/apps/web/src/components/chat-view.tsx
+++ b/apps/web/src/components/chat-view.tsx
@@ -65,10 +65,10 @@ function ChatInput({
 
   return (
     <div className="sticky bottom-0 pb-4 z-10 bg-background">
-      <div className="flex gap-2 max-w-5xl mx-auto w-full h-10">
+      <div className="flex gap-2 max-w-5xl mx-auto w-full h-10 px-4">
         <Input
           className="bg-background h-full"
-          placeholder="Yap, yap, yap..."
+          placeholder="Ask anything"
           value={input}
           onChange={handleInputChange}
           disabled={disabled}


### PR DESCRIPTION
### TL;DR

Improved sidebar UI and chat input experience with cleaner design and better user interactions.

### What changed?

- Removed `SidebarGroupLabel` import that was unused
- Removed `SidebarSeparator` between sidebar groups
- Replaced the delete chat button with a simpler implementation:
  - Changed from a `Button` component to a `div`
  - Added navigation to home when deleting the currently active chat
  - Fixed styling issues with the delete action
- Updated the chat input placeholder from "Yap, yap, yap..." to "Ask anything"
- Added padding to the chat input container with `px-4`

### How to test?

1. Navigate to the sidebar and verify the separator between groups is gone
2. Create a chat and test the delete functionality:
   - Delete a non-active chat and verify it disappears
   - Delete the currently active chat and verify it redirects to home
3. Check that the chat input has proper padding and displays "Ask anything" as placeholder text

### Why make this change?

These changes improve the user experience by simplifying the UI, making the delete chat functionality more reliable (especially when deleting the active chat), and providing a more professional placeholder text for the chat input that better guides users.