### PR TITLE
feat(web): add pinned chats

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -3,5 +3,6 @@
 .nitro
 .output
 .tanstack-start
+.vercel
 .DS_Store
 node_modules

--- a/apps/web/convex/_generated/api.d.ts
+++ b/apps/web/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type {
 } from "convex/server";
 import type * as betterAuth from "../betterAuth.js";
 import type * as functions_chat from "../functions/chat.js";
+import type * as functions_chatMember from "../functions/chatMember.js";
 import type * as functions_message from "../functions/message.js";
 
 /**
@@ -28,6 +29,7 @@ import type * as functions_message from "../functions/message.js";
 declare const fullApi: ApiFromModules<{
   betterAuth: typeof betterAuth;
   "functions/chat": typeof functions_chat;
+  "functions/chatMember": typeof functions_chatMember;
   "functions/message": typeof functions_message;
 }>;
 export declare const api: FilterApi<

--- a/apps/web/convex/functions/chatMember.ts
+++ b/apps/web/convex/functions/chatMember.ts
@@ -1,0 +1,104 @@
+import { v } from "convex/values";
+import { internalMutation, internalQuery } from "../_generated/server";
+import { internal } from "../_generated/api";
+
+export const createChatMember = internalMutation({
+  args: {
+    chatId: v.id("chat"),
+    userId: v.id("user"),
+    role: v.optional(v.string()),
+    invitedBy: v.optional(v.id("user")),
+    pinnedAt: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { chatId, userId, role, invitedBy, pinnedAt } = args;
+
+    const now = new Date().toISOString();
+    await ctx.db.insert("chatMember", {
+      chatId,
+      userId,
+      role,
+      invitedBy,
+      pinnedAt,
+      joinedAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+export const getChatMember = internalQuery({
+  args: {
+    chatId: v.id("chat"),
+    userId: v.id("user"),
+  },
+  handler: async (ctx, args) => {
+    const { chatId, userId } = args;
+
+    const chatMember = await ctx.db.query("chatMember").filter((q) => q.eq(q.field("chatId"), chatId)).filter((q) => q.eq(q.field("userId"), userId)).first();
+    return chatMember;
+  },
+}); 
+
+export const updateChatMember = internalMutation({
+  args: {
+    chatId: v.id("chat"),
+    userId: v.id("user"),
+    role: v.optional(v.string()),
+    invitedBy: v.optional(v.id("user")),
+    pinnedAt: v.optional(v.string()),
+    sessionToken: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { sessionToken, chatId, userId, ...fields } = args;
+
+    const session = await ctx.runQuery(internal.betterAuth.getSession, {
+      sessionToken,
+    });
+
+    if (!session) {
+      throw new Error("Unauthorized");
+    }
+
+    const chatMember = await ctx.runQuery(internal.functions.chatMember.getChatMember, {
+      chatId,
+      userId,
+    });
+    if (!chatMember) {
+      return;
+    }
+
+    const patch: Record<string, unknown> = { updatedAt: new Date().toISOString() };
+    const keys = [
+      "role" as const,
+      "invitedBy" as const,
+      "pinnedAt" as const,
+    ];
+
+    for (const key of keys) {
+      if (fields[key] !== undefined) patch[key] = fields[key];
+      if (fields[key] === "unpin") patch[key] = undefined;
+    }
+
+    await ctx.db.patch(chatMember._id, patch);
+  },
+});
+
+export const deleteChatMember = internalMutation({
+  args: {
+    chatId: v.id("chat"),
+    userId: v.id("user"),
+  },
+  handler: async (ctx, args) => {
+    const { chatId, userId } = args;
+
+    const chatMember = await ctx.runQuery(internal.functions.chatMember.getChatMember, {
+      chatId,
+      userId,
+    });
+    if (!chatMember) {
+      return;
+    }
+
+    await ctx.db.delete(chatMember._id);
+  },
+});

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -40,6 +40,8 @@ export default defineSchema({
     pinnedAt: v.optional(v.string()),
     // When the user joined the chat
     joinedAt: v.string(),
+    // When the user was last updated
+    updatedAt: v.string(),
   })
     .index("by_chatId", ["chatId"])
     .index("by_userId", ["userId"]),

--- a/apps/web/src/components/chat-view.tsx
+++ b/apps/web/src/components/chat-view.tsx
@@ -104,9 +104,7 @@ export function ChatView() {
   const updateChat = useMutation(api.functions.chat.updateChat);
   const getChatMessages = useQuery(
     api.functions.chat.getChatMessages,
-    chatId && session
-      ? { chatId: chatId as Id<"chat">, sessionToken: session.session.token }
-      : "skip"
+    chatId ? { chatId: chatId as Id<"chat">, sessionToken: session?.session.token } : "skip"
   );
 
   const { messages, status, append } = useChat({


### PR DESCRIPTION
### TL;DR

Added chat pinning functionality and improved chat member management with a new `chatMember` table.

### What changed?

- Added ability to pin and unpin chats in the sidebar
- Created a new `chatMember` module to manage chat membership
- Updated the sidebar UI to display pinned chats in a separate section
- Added `.vercel` to the `.gitignore` file
- Enhanced chat visibility permissions to support public/private chats
- Improved chat deletion to properly clean up chat member records
- Added `updatedAt` field to the chat member schema

### How to test?

1. Create a new chat
2. Click the pin icon next to a chat in the sidebar to pin it
3. Verify the chat appears in the "Pinned" section
4. Click the unpin icon to move it back to the regular chats section
5. Test chat deletion to ensure it properly removes all associated records
6. Verify that private chats are only accessible to members

### Why make this change?

This change improves the user experience by allowing users to organize their chats by pinning important conversations. It also establishes a proper chat membership system that will enable future features like inviting users to chats and managing permissions. The separation of chat member logic into its own module creates a cleaner code structure and better separation of concerns.