### PR TITLE
fix(web): invalid chat id bug

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -18,6 +18,7 @@ import { api } from "~/lib/db/server";
 import { Pin, PinOff, X } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { useMutation } from "convex/react";
+import { Separator } from "~/components/ui/seperator";
 
 export function AppSidebar() {
   const { data: session } = authClient.useSession();
@@ -57,6 +58,7 @@ export function AppSidebar() {
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
+        <Separator />
         {pinned.length > 0 && (
           <SidebarGroup>
             <SidebarGroupContent>
@@ -79,7 +81,7 @@ export function AppSidebar() {
                         </span>
                       </Link>
                     </SidebarMenuButton>
-                    <div className="absolute right-1 top-1.5 z-10 flex flex-row gap-1 items-center group-hover/item:bg-sidebar-accent">
+                    <div className="hidden absolute right-1 top-1.5 z-10 group-hover/item:flex flex-row gap-1 items-center group-hover/item:bg-sidebar-accent">
                       <SidebarMenuAction
                         showOnHover
                         onClick={async (e) => {
@@ -138,7 +140,7 @@ export function AppSidebar() {
                       </span>
                     </Link>
                   </SidebarMenuButton>
-                  <div className="absolute right-1 top-1.5 z-10 flex flex-row gap-1 items-center group-hover/item:bg-sidebar-accent">
+                  <div className="hidden absolute right-1 top-1.5 z-10 group-hover/item:flex flex-row gap-1 items-center group-hover/item:bg-sidebar-accent">
                     <SidebarMenuAction
                       showOnHover
                       onClick={async (e) => {

--- a/apps/web/src/components/chat-view.tsx
+++ b/apps/web/src/components/chat-view.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "./ui/select";
 import { models, getDefaultModel } from "~/lib/models";
+import { isConvexId } from "~/lib/db/utils";
 
 interface ChatInputProps {
   chatId?: string;
@@ -138,9 +139,7 @@ export function ChatView() {
   const updateChat = useMutation(api.functions.chat.updateChat);
   const getChatMessages = useQuery(
     api.functions.chat.getChatMessages,
-    chatId
-      ? { chatId: chatId as Id<"chat">, sessionToken: session?.session.token }
-      : "skip"
+    isConvexId<"chat">(chatId) ? { chatId: chatId , sessionToken: session?.session.token } : "skip"
   );
 
   const { messages, status, append } = useChat({

--- a/apps/web/src/lib/db/utils.ts
+++ b/apps/web/src/lib/db/utils.ts
@@ -1,0 +1,9 @@
+import type { Id, TableNames } from "convex/_generated/dataModel";
+import type { SystemTableNames } from "convex/server";
+
+export function isConvexId<T extends TableNames | SystemTableNames>(id: string | undefined): id is Id<T> {
+  return (
+    typeof id === "string" &&
+    (/^[a-z0-9]{32}$/.test(id))
+  );
+}


### PR DESCRIPTION
### TL;DR

Added a separator between sidebar sections and improved UI by hiding action buttons until hover.

### What changed?

- Added a `Separator` component between sidebar groups to visually distinguish sections
- Changed action buttons in the sidebar to be hidden by default and only appear on hover
- Created a new utility function `isConvexId<T>()` to validate Convex IDs
- Simplified the chat message query logic using the new ID validation function

### How to test?

1. Navigate through the sidebar and verify that there's a visual separator between sections
2. Hover over sidebar items to confirm that action buttons (like pin/unpin) only appear on hover
3. Check that chat functionality works correctly with the updated ID validation

### Why make this change?

These changes improve the user experience by:
- Making the sidebar cleaner and less cluttered by hiding action buttons until needed
- Adding visual separation between sidebar sections for better organization
- Implementing a type-safe way to validate Convex IDs, which improves code reliability and maintainability