### PR TITLE
refactor(web): abstract data persistence to modular hook

### DIFF
--- a/apps/web/src/hooks/useChatsList.ts
+++ b/apps/web/src/hooks/useChatsList.ts
@@ -1,38 +1,19 @@
 import { authClient } from "~/lib/auth/client";
 import { api } from "~/lib/db/server";
 import { useQuery as useConvexQuery } from "convex/react";
-import {
-  useQuery as useTanstackQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
-import { useEffect } from "react";
+import { usePersistedQuery } from "~/hooks/usePersistedQuery";
 
 export function useChatsList() {
   const { data: session } = authClient.useSession();
-  const queryClient = useQueryClient();
 
   const serverChats = useConvexQuery(
     api.functions.chat.getUserChats,
     session ? { sessionToken: session.session.token } : "skip"
   );
 
-  useEffect(() => {
-    if (serverChats) {
-      queryClient.setQueryData(["chats:listMeta"], serverChats);
-    }
-  }, [serverChats, queryClient]);
-
-  return useTanstackQuery({
+  return usePersistedQuery({
     queryKey: ["chats:listMeta"],
-    queryFn: async () => {
-      return serverChats || [];
-    },
-    initialData: serverChats || undefined,
+    dataSource: serverChats,
     enabled: !!session,
-    staleTime: 1000 * 60 * 60 * 24,
-    gcTime: 1000 * 60 * 60 * 24,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: true,
   });
 }

--- a/apps/web/src/hooks/usePersistedQuery.ts
+++ b/apps/web/src/hooks/usePersistedQuery.ts
@@ -1,0 +1,44 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
+
+interface UsePersistedQueryOptions<T> {
+  queryKey: readonly string[];
+  dataSource: T | undefined;
+  enabled?: boolean;
+  staleTime?: number;
+  gcTime?: number;
+}
+
+export function usePersistedQuery<T>({
+  queryKey,
+  dataSource,
+  enabled = true,
+  staleTime,
+  gcTime,
+}: UsePersistedQueryOptions<T>) {
+  const queryClient = useQueryClient();
+
+  const queryKeyString = JSON.stringify(queryKey);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: We intentionally use queryKeyString to stabilize the array reference
+  const stableQueryKey = useMemo(
+    () => ["persisted", ...queryKey],
+    [queryKeyString]
+  );
+
+  useEffect(() => {
+    if (dataSource !== undefined) {
+      queryClient.setQueryData(stableQueryKey, dataSource);
+    }
+  }, [dataSource, queryClient, stableQueryKey]);
+
+  return useQuery({
+    queryKey: stableQueryKey,
+    queryFn: async () => {
+      return dataSource || [];
+    },
+    initialData: dataSource || undefined,
+    enabled,
+    ...(staleTime !== undefined && { staleTime }),
+    ...(gcTime !== undefined && { gcTime }),
+  });
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -23,7 +23,13 @@ export function createRouter() {
       queries: {
         queryKeyHashFn: convexQueryClient.hashFn(),
         queryFn: convexQueryClient.queryFn(),
+        staleTime: 1000 * 60 * 60 * 24,
         gcTime: 1000 * 60 * 60 * 24,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: true,
+        retry: 3,
+        retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
       },
     },
   });
@@ -49,8 +55,12 @@ export function createRouter() {
             persistOptions={{
               persister,
               dehydrateOptions: {
-                shouldDehydrateQuery: (q) => q.queryKey[0] === "chats:listMeta",
+                shouldDehydrateQuery: (q) => {
+                  const key = q.queryKey[0];
+                  return key === "persisted";
+                },
               },
+              buster: "v1",
             }}
           >
             <ConvexProvider client={convexQueryClient.convexClient}>


### PR DESCRIPTION
# Refactor Query Persistence with New `usePersistedQuery` Hook

### TL;DR

Created a reusable `usePersistedQuery` hook to standardize how we persist data from Convex to React Query.

### What changed?

- Created a new `usePersistedQuery` hook that abstracts the logic for persisting data between Convex and React Query
- Refactored `useChatsList` to use the new hook, simplifying its implementation
- Updated the query persistence configuration in the router:
  - Added default query settings (staleTime, refetch behavior, retry logic)
  - Modified the dehydration logic to target queries with the "persisted" key
  - Added a version buster ("v1") to the persistence options

### How to test?

1. Verify that chat lists still load correctly
2. Check that chat data persists between page refreshes
3. Confirm that the application correctly handles offline/reconnection scenarios

### Why make this change?

This refactoring improves code maintainability by centralizing the persistence logic into a reusable hook. It standardizes how we handle data persistence between Convex and React Query, making it easier to implement this pattern in other parts of the application. The added configuration options also improve the reliability of data fetching with better retry logic and cache management.