### PR TITLE
docs(web): add documentation for persisted queries

### DIFF
--- a/apps/web/src/hooks/README.md
+++ b/apps/web/src/hooks/README.md
@@ -1,0 +1,99 @@
+# Persisted Query
+
+The `usePersistedQuery` hook automatically syncs data from any source with TanStack Query and persists it to localStorage.
+
+## Options
+
+- `queryKey` - Array of strings that uniquely identify this query. Will be prefixed with "persisted" automatically
+- `dataSource` - The reactive data source (e.g., from Convex, fetch, etc.) to sync with TanStack Query
+- `enabled` - Whether the query should be enabled. Defaults to true
+- `staleTime` - Time in milliseconds that data is considered fresh. Inherits from global config if not provided
+- `gcTime` - Time in milliseconds that unused/inactive cache data remains in memory. Should match or exceed the persistence maxAge (24 hours). Set to `Infinity` to disable garbage collection
+
+## Usage Examples
+
+### Basic Chat List
+
+```typescript
+export function useChatsList() {
+  const { data: session } = authClient.useSession();
+
+  const serverChats = useConvexQuery(
+    api.functions.chat.getUserChats,
+    session ? { sessionToken: session.session.token } : "skip"
+  );
+
+  return usePersistedQuery({
+    queryKey: ["chats:listMeta"], // becomes ["persisted", "chats:listMeta"] internally
+    dataSource: serverChats,
+    enabled: !!session,
+  });
+}
+```
+
+### Messages for a Chat
+
+```typescript
+export function useMessages(chatId: string) {
+  const serverMessages = useConvexQuery(api.functions.message.list, { chatId });
+
+  return usePersistedQuery({
+    queryKey: ["messages", chatId], // becomes ["persisted", "messages", chatId] internally
+    dataSource: serverMessages,
+    enabled: !!chatId,
+  });
+}
+```
+
+### User Profile
+
+```typescript
+export function useUserProfile() {
+  const { data: session } = authClient.useSession();
+
+  const serverProfile = useConvexQuery(
+    api.functions.user.getProfile,
+    session ? { sessionToken: session.session.token } : "skip"
+  );
+
+  return usePersistedQuery({
+    queryKey: ["user:profile"], // becomes ["persisted", "user:profile"] internally
+    dataSource: serverProfile,
+    enabled: !!session,
+  });
+}
+```
+
+### External API Data
+
+```typescript
+export function useExternalData() {
+  const [data, setData] = useState();
+
+  useEffect(() => {
+    fetch("/api/external")
+      .then((res) => res.json())
+      .then(setData);
+  }, []);
+
+  return usePersistedQuery({
+    queryKey: ["external:data"], // becomes ["persisted", "external:data"] internally
+    dataSource: data,
+  });
+}
+```
+
+## How It Works
+
+The hook automatically adds `"persisted"` as the first element of your query key. The router only persists queries that start with `"persisted"`. When your data source changes, it automatically updates the TanStack Query cache and persists the new data.
+
+## Query Key Structure
+
+```
+Your input:      ["chats:listMeta"]
+Internal key:    ["persisted", "chats:listMeta"]
+Gets persisted:  Yes
+
+Regular useQuery: ["some:data"]
+Gets persisted:   No
+```

--- a/apps/web/src/hooks/usePersistedQuery.ts
+++ b/apps/web/src/hooks/usePersistedQuery.ts
@@ -1,6 +1,15 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
 
+/**
+ * Options for the usePersistedQuery hook
+ * @template T The type of data being queried
+ * @param queryKey - Array of strings that uniquely identify this query. Will be prefixed with "persisted" automatically
+ * @param dataSource - The reactive data source (e.g., from Convex, fetch, etc.) to sync with TanStack Query
+ * @param enabled - Whether the query should be enabled. Defaults to true
+ * @param staleTime - Time in milliseconds that data is considered fresh. Inherits from global config if not provided
+ * @param gcTime - Time in milliseconds that unused/inactive cache data remains in memory. Inherits from global config if not provided. Set to `Infinity` to disable garbage collection
+ */
 interface UsePersistedQueryOptions<T> {
   queryKey: readonly string[];
   dataSource: T | undefined;
@@ -9,6 +18,18 @@ interface UsePersistedQueryOptions<T> {
   gcTime?: number;
 }
 
+/**
+ * A hook that automatically syncs data from any reactive source with TanStack Query and persists it to localStorage.
+ *
+ * This hook bridges reactive data sources (like Convex queries) with TanStack Query's caching system,
+ * automatically persisting the data to localStorage for offline access and faster initial loads.
+ *
+ * @template T The type of data being queried
+ * @param options Configuration options for the persisted query
+ * @returns TanStack Query result object with the synced and persisted data
+ *
+
+ */
 export function usePersistedQuery<T>({
   queryKey,
   dataSource,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -54,6 +54,7 @@ export function createRouter() {
             client={queryClient}
             persistOptions={{
               persister,
+              maxAge: 1000 * 60 * 60 * 24,
               dehydrateOptions: {
                 shouldDehydrateQuery: (q) => {
                   const key = q.queryKey[0];


### PR DESCRIPTION
# Add usePersistedQuery Documentation and Enhance Implementation

### TL;DR

Added comprehensive documentation for the `usePersistedQuery` hook and improved its implementation with better JSDoc comments and persistence configuration.

### What changed?

- Added a detailed README.md for the `usePersistedQuery` hook with:
  - Clear explanation of the hook's purpose
  - Documentation of all available options
  - Multiple usage examples for different scenarios (chat lists, messages, user profiles, external API data)
  - Explanation of how the persistence mechanism works
- Enhanced the `usePersistedQuery.ts` implementation with:
  - Comprehensive JSDoc comments for better developer experience
  - Improved type documentation
- Updated the router configuration to set a 24-hour maximum age for persisted queries

### How to test?

1. Review the new documentation in `apps/web/src/hooks/README.md`
2. Try implementing the hook in a component following one of the provided examples
3. Verify that data persists in localStorage between page refreshes
4. Check that persisted data expires after 24 hours as configured

### Why make this change?

This change improves developer experience by providing clear documentation and usage examples for the `usePersistedQuery` hook. The enhanced JSDoc comments make the API more discoverable through IDE tooltips, while the README provides comprehensive guidance on best practices. Setting a maximum age for persisted queries ensures we don't keep stale data indefinitely, balancing offline capabilities with data freshness.