### PR TITLE
build(vercel): disable all deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": {
-      "*": false,
-      "main": true,
-      "dev": true
-    }
+    "deploymentEnabled": true
   }
 }


### PR DESCRIPTION
### TL;DR

Enable Vercel deployments for all branches.

### What changed?

Modified `vercel.json` to enable deployments for all branches by changing the `deploymentEnabled` property from a conditional object to a simple boolean value of `true`. Previously, deployments were only enabled for the `main` and `dev` branches, while all other branches had deployments disabled.

### How to test?

1. Push changes to any branch other than `main` or `dev`
2. Verify that Vercel automatically creates a deployment for that branch
3. Check that the preview deployment works as expected

### Why make this change?

This change enables preview deployments for all branches, which improves the development workflow by allowing team members to preview changes on any branch before merging. This facilitates easier testing and collaboration across the team, especially for feature branches that need to be reviewed.