### PR TITLE
build(vercel): disable all deployment like actually

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": true
+    "deploymentEnabled": false
   }
 }


### PR DESCRIPTION
### TL;DR

Disabled automatic Vercel deployments for git pushes.

### What changed?

Changed the `deploymentEnabled` flag from `true` to `false` in the `vercel.json` configuration file. This prevents Vercel from automatically creating deployments when new git commits are pushed.

### How to test?

1. Push a new commit to the repository
2. Verify that Vercel does not automatically create a new deployment
3. Confirm that manual deployments still work as expected

### Why make this change?

This change gives more control over when deployments occur, preventing unnecessary deployments for every push and allowing for more intentional release management. This can help reduce resource usage and provide better control over which code changes are deployed to production.