### PR TITLE
feat(web): add search toggle and refactor options

### DIFF
--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -5,52 +5,8 @@ import { api } from "~/lib/db/server";
 import { Input } from "~/components/ui/input";
 import { Button } from "~/components/ui/button";
 import { ArrowUpIcon } from "lucide-react";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/ui/select";
-import { models } from "~/lib/models";
 import { inputStore } from "~/components/chat/stores";
-
-interface ModelSelectorProps {
-  selectedModelId: number;
-  onModelChange: (modelId: number) => void;
-}
-
-const ModelSelector = memo(function ModelSelector({
-  selectedModelId,
-  onModelChange,
-}: ModelSelectorProps) {
-  const handleModelChange = useCallback(
-    (value: string) => {
-      onModelChange(Number.parseInt(value));
-    },
-    [onModelChange]
-  );
-
-  return (
-    <div className="flex justify-start">
-      <Select
-        value={selectedModelId.toString()}
-        onValueChange={handleModelChange}
-      >
-        <SelectTrigger className="w-[200px]">
-          <SelectValue placeholder="Select model" />
-        </SelectTrigger>
-        <SelectContent>
-          {models.map((model) => (
-            <SelectItem key={model.id} value={model.id.toString()}>
-              {model.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-});
+import { ChatOptions } from "~/components/chat/chat-options";
 
 interface ChatInputProps {
   chatId?: string;
@@ -161,7 +117,7 @@ const ChatInput = memo(function ChatInput({
             )}
           </Button>
         </div>
-        <ModelSelector
+        <ChatOptions
           selectedModelId={selectedModelId}
           onModelChange={onModelChange}
         />

--- a/apps/web/src/components/chat/chat-options.tsx
+++ b/apps/web/src/components/chat/chat-options.tsx
@@ -1,0 +1,25 @@
+import { memo } from "react";
+import {
+  ModelSelector,
+  type ModelSelectorProps,
+} from "~/components/chat/model-selector";
+import { ChatToggles } from "~/components/chat/chat-toggles";
+
+interface ChatOptionsProps extends ModelSelectorProps {}
+
+const ChatOptions = memo(function ChatOptions({
+  selectedModelId,
+  onModelChange,
+}: ChatOptionsProps) {
+  return (
+    <div className="flex gap-2 items-center">
+      <ModelSelector
+        selectedModelId={selectedModelId}
+        onModelChange={onModelChange}
+      />
+      <ChatToggles />
+    </div>
+  );
+});
+
+export { ChatOptions, type ChatOptionsProps };

--- a/apps/web/src/components/chat/chat-toggles.tsx
+++ b/apps/web/src/components/chat/chat-toggles.tsx
@@ -1,0 +1,39 @@
+import { memo, useCallback } from "react";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+import { Icon } from "@iconify/react";
+import { usePersisted } from "~/hooks/usePersisted";
+
+export interface ToggleState {
+  search: boolean;
+}
+
+const ChatToggles = memo(function ChatToggles() {
+  const { value: toggles, set: setToggles } = usePersisted<ToggleState>(
+    "chat-toggle-options",
+    { search: false }
+  );
+
+  const groupValue = toggles.search ? ["search"] : [];
+
+  const handleChange = useCallback(
+    (values: string[]) => {
+      setToggles((prev) => ({ ...prev, search: values.includes("search") }));
+    },
+    [setToggles]
+  );
+
+  return (
+    <ToggleGroup
+      type="multiple"
+      variant="outline"
+      value={groupValue}
+      onValueChange={handleChange}
+    >
+      <ToggleGroupItem value="search" size="default">
+        <Icon icon="lucide:globe" className="bg-transparent" />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
+});
+
+export { ChatToggles };

--- a/apps/web/src/components/chat/model-selector.tsx
+++ b/apps/web/src/components/chat/model-selector.tsx
@@ -1,0 +1,48 @@
+import { memo, useCallback } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { models } from "~/lib/models";
+
+interface ModelSelectorProps {
+  selectedModelId: number;
+  onModelChange: (modelId: number) => void;
+}
+
+const ModelSelector = memo(function ModelSelector({
+  selectedModelId,
+  onModelChange,
+}: ModelSelectorProps) {
+  const handleModelChange = useCallback(
+    (value: string) => {
+      onModelChange(Number.parseInt(value));
+    },
+    [onModelChange]
+  );
+
+  return (
+    <div className="flex justify-start">
+      <Select
+        value={selectedModelId.toString()}
+        onValueChange={handleModelChange}
+      >
+        <SelectTrigger className="w-[200px]">
+          <SelectValue placeholder="Select model" />
+        </SelectTrigger>
+        <SelectContent>
+          {models.map((model) => (
+            <SelectItem key={model.id} value={model.id.toString()}>
+              {model.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+});
+
+export { ModelSelector, type ModelSelectorProps };


### PR DESCRIPTION
### TL;DR

Added a web search toggle feature to the chat interface that allows users to enable/disable web search for AI responses.

### What changed?

- Refactored the chat UI components by extracting the `ModelSelector` into its own component
- Created a new `ChatOptions` component that combines the model selector with new toggle controls
- Implemented `ChatToggles` component with a web search toggle option (globe icon)
- Added state persistence for toggle options using the `usePersisted` hook
- Modified the chat functionality to include the search toggle state when sending messages
- Added logic to reset toggles after sending a message

### How to test?

1. Open the chat interface
2. Look for the new globe icon toggle button next to the model selector
3. Enable the web search toggle
4. Send a message to the AI
5. Verify that the response includes web search results
6. Confirm that the toggle resets after sending the message

### Why make this change?

This change enhances the chat functionality by allowing users to explicitly request web search capabilities when needed. By making web search an opt-in feature through a toggle, users have more control over the AI's response generation process, enabling more contextually relevant answers for queries that benefit from up-to-date information from the web.