### PR TITLE
feat(web): persist model selection in local storage

### DIFF
--- a/apps/web/src/components/chat-view.tsx
+++ b/apps/web/src/components/chat-view.tsx
@@ -7,6 +7,7 @@ import { usePersisted } from "~/hooks/usePersisted";
 import type { ToggleState } from "~/components/chat/chat-toggles";
 import type { Doc, Id } from "convex/_generated/dataModel";
 import { Message } from "~/components/message";
+import { MODEL_PERSIST_KEY } from "~/components/chat/model-selector";
 import { getDefaultModel } from "~/lib/models";
 import { isConvexId } from "~/lib/db/utils";
 import { ChatInput } from "~/components/chat/chat-input";
@@ -22,7 +23,8 @@ export function ChatView() {
   const params = useParams({ strict: false }) as { chatId?: string };
   const chatId = params?.chatId;
 
-  const [selectedModelId, setSelectedModelId] = useState<number>(
+  const { value: selectedModelId } = usePersisted<number>(
+    MODEL_PERSIST_KEY,
     getDefaultModel().id
   );
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -226,8 +228,6 @@ export function ChatView() {
         sessionToken={session?.session.token ?? "skip"}
         disabled={status === "streaming"}
         addUserMessage={addUserMessage}
-        selectedModelId={selectedModelId}
-        onModelChange={setSelectedModelId}
       />
     </div>
   );

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -12,8 +12,6 @@ interface ChatInputProps {
   chatId?: string;
   sessionToken: string;
   disabled: boolean;
-  selectedModelId: number;
-  onModelChange: (modelId: number) => void;
   addUserMessage: (message: string) => void;
 }
 
@@ -21,8 +19,6 @@ const ChatInput = memo(function ChatInput({
   chatId,
   sessionToken,
   disabled,
-  selectedModelId,
-  onModelChange,
   addUserMessage,
 }: ChatInputProps) {
   const navigate = useNavigate();
@@ -117,10 +113,7 @@ const ChatInput = memo(function ChatInput({
             )}
           </Button>
         </div>
-        <ChatOptions
-          selectedModelId={selectedModelId}
-          onModelChange={onModelChange}
-        />
+        <ChatOptions />
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/chat-options.tsx
+++ b/apps/web/src/components/chat/chat-options.tsx
@@ -1,25 +1,14 @@
 import { memo } from "react";
-import {
-  ModelSelector,
-  type ModelSelectorProps,
-} from "~/components/chat/model-selector";
+import { ModelSelector } from "~/components/chat/model-selector";
 import { ChatToggles } from "~/components/chat/chat-toggles";
 
-interface ChatOptionsProps extends ModelSelectorProps {}
-
-const ChatOptions = memo(function ChatOptions({
-  selectedModelId,
-  onModelChange,
-}: ChatOptionsProps) {
+const ChatOptions = memo(function ChatOptions() {
   return (
     <div className="flex gap-2 items-center">
-      <ModelSelector
-        selectedModelId={selectedModelId}
-        onModelChange={onModelChange}
-      />
+      <ModelSelector />
       <ChatToggles />
     </div>
   );
 });
 
-export { ChatOptions, type ChatOptionsProps };
+export { ChatOptions };

--- a/apps/web/src/components/chat/model-selector.tsx
+++ b/apps/web/src/components/chat/model-selector.tsx
@@ -6,22 +6,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select";
-import { models } from "~/lib/models";
+import { models, getDefaultModel } from "~/lib/models";
+import { usePersisted } from "~/hooks/usePersisted";
 
-interface ModelSelectorProps {
-  selectedModelId: number;
-  onModelChange: (modelId: number) => void;
-}
+export const MODEL_PERSIST_KEY = "selected-model";
 
-const ModelSelector = memo(function ModelSelector({
-  selectedModelId,
-  onModelChange,
-}: ModelSelectorProps) {
+const ModelSelector = memo(function ModelSelector() {
+  const { value: selectedModelId, set: setSelectedModelId } =
+    usePersisted<number>(MODEL_PERSIST_KEY, getDefaultModel().id);
+
   const handleModelChange = useCallback(
     (value: string) => {
-      onModelChange(Number.parseInt(value));
+      setSelectedModelId(Number.parseInt(value));
     },
-    [onModelChange]
+    [setSelectedModelId]
   );
 
   return (
@@ -45,4 +43,4 @@ const ModelSelector = memo(function ModelSelector({
   );
 });
 
-export { ModelSelector, type ModelSelectorProps };
+export { ModelSelector };


### PR DESCRIPTION
### TL;DR

Refactored model selection to use persisted state, removing prop drilling.

### What changed?

- Added a `MODEL_PERSIST_KEY` constant for storing the selected model ID
- Refactored the model selection to use the `usePersisted` hook instead of passing props through components
- Removed `selectedModelId` and `onModelChange` props from `ChatInput` and `ChatOptions` components
- Simplified the component interfaces by removing unnecessary props and types

### How to test?

1. Open the chat interface
2. Select a different model from the dropdown
3. Refresh the page or navigate away and back
4. Verify that your model selection persists across page loads

### Why make this change?

This change improves the code architecture by:
1. Eliminating prop drilling through multiple component layers
2. Persisting user model preferences across sessions
3. Making the components more independent and easier to maintain
4. Centralizing the model selection state management