### PR TITLE
feat(web): add tooltips for sidebar and search

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -20,6 +20,11 @@ import { Button } from "~/components/ui/button";
 import { useMutation } from "convex/react";
 import { Separator } from "~/components/ui/seperator";
 import { useChatsList } from "~/hooks/useChatsList";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
 
 export function AppSidebar() {
   const { data: session } = authClient.useSession();
@@ -81,43 +86,64 @@ export function AppSidebar() {
                         to="/chat/$chatId"
                         params={{ chatId: chat._id }}
                       >
-                        <span className="block truncate max-w-full">
-                          {chat.title}
-                        </span>
+                        <Tooltip>
+                          <TooltipTrigger className="truncate">
+                            <span className="block truncate max-w-full">
+                              {chat.title}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent hideWhenDetached>
+                            <p>{chat.title}</p>
+                          </TooltipContent>
+                        </Tooltip>
                       </Link>
                     </SidebarMenuButton>
                     <div className="hidden absolute right-1 top-1.5 z-10 group-hover/item:flex flex-row gap-1 items-center group-hover/item:bg-sidebar-accent">
-                      <SidebarMenuAction
-                        showOnHover
-                        onClick={async (e) => {
-                          e.stopPropagation();
-                          e.preventDefault();
-                          await unpinChat({
-                            chatId: chat._id,
-                            sessionToken: session?.session.token ?? "",
-                          });
-                        }}
-                        className="static hover:text-blue-500 hover:cursor-pointer"
-                      >
-                        <PinOff className="size-4" />
-                      </SidebarMenuAction>
-                      <SidebarMenuAction
-                        showOnHover
-                        onClick={async (e) => {
-                          e.stopPropagation();
-                          e.preventDefault();
-                          await deleteChat({
-                            chatId: chat._id,
-                            sessionToken: session?.session.token ?? "",
-                          });
-                          if (params.chatId === chat._id) {
-                            navigate({ to: "/" });
-                          }
-                        }}
-                        className="static hover:text-destructive hover:cursor-pointer"
-                      >
-                        <X className="size-4" />
-                      </SidebarMenuAction>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <SidebarMenuAction
+                            showOnHover
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                              await unpinChat({
+                                chatId: chat._id,
+                                sessionToken: session?.session.token ?? "",
+                              });
+                            }}
+                            className="static hover:text-blue-500 hover:cursor-pointer"
+                          >
+                            <PinOff className="size-4" />
+                          </SidebarMenuAction>
+                        </TooltipTrigger>
+                        <TooltipContent hideWhenDetached>
+                          <p>Unpin</p>
+                        </TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <SidebarMenuAction
+                            showOnHover
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                              await deleteChat({
+                                chatId: chat._id,
+                                sessionToken: session?.session.token ?? "",
+                              });
+                              if (params.chatId === chat._id) {
+                                navigate({ to: "/" });
+                              }
+                            }}
+                            className="static hover:text-destructive hover:cursor-pointer"
+                          >
+                            <X className="size-4" />
+                          </SidebarMenuAction>
+                        </TooltipTrigger>
+                        <TooltipContent hideWhenDetached>
+                          <p>Delete</p>
+                        </TooltipContent>
+                      </Tooltip>
                     </div>
                   </SidebarMenuItem>
                 ))}
@@ -140,43 +166,64 @@ export function AppSidebar() {
                       to="/chat/$chatId"
                       params={{ chatId: chat._id }}
                     >
-                      <span className="block truncate max-w-full">
-                        {chat.title}
-                      </span>
+                      <Tooltip>
+                        <TooltipTrigger className="truncate">
+                          <span className="block truncate max-w-full">
+                            {chat.title}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent hideWhenDetached>
+                          <p>{chat.title}</p>
+                        </TooltipContent>
+                      </Tooltip>
                     </Link>
                   </SidebarMenuButton>
                   <div className="hidden absolute right-1 top-1.5 z-10 group-hover/item:flex flex-row gap-1 items-center group-hover/item:bg-sidebar-accent">
-                    <SidebarMenuAction
-                      showOnHover
-                      onClick={async (e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        await pinChat({
-                          chatId: chat._id,
-                          sessionToken: session?.session.token ?? "",
-                        });
-                      }}
-                      className="static hover:text-blue-500 hover:cursor-pointer"
-                    >
-                      <Pin className="size-4" />
-                    </SidebarMenuAction>
-                    <SidebarMenuAction
-                      showOnHover
-                      onClick={async (e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        await deleteChat({
-                          chatId: chat._id,
-                          sessionToken: session?.session.token ?? "",
-                        });
-                        if (params.chatId === chat._id) {
-                          navigate({ to: "/" });
-                        }
-                      }}
-                      className="static hover:text-destructive hover:cursor-pointer"
-                    >
-                      <X className="size-4" />
-                    </SidebarMenuAction>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <SidebarMenuAction
+                          showOnHover
+                          onClick={async (e) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            await pinChat({
+                              chatId: chat._id,
+                              sessionToken: session?.session.token ?? "",
+                            });
+                          }}
+                          className="static hover:text-blue-500 hover:cursor-pointer"
+                        >
+                          <Pin className="size-4" />
+                        </SidebarMenuAction>
+                      </TooltipTrigger>
+                      <TooltipContent hideWhenDetached>
+                        <p>Pin</p>
+                      </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <SidebarMenuAction
+                          showOnHover
+                          onClick={async (e) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            await deleteChat({
+                              chatId: chat._id,
+                              sessionToken: session?.session.token ?? "",
+                            });
+                            if (params.chatId === chat._id) {
+                              navigate({ to: "/" });
+                            }
+                          }}
+                          className="static hover:text-destructive hover:cursor-pointer"
+                        >
+                          <X className="size-4" />
+                        </SidebarMenuAction>
+                      </TooltipTrigger>
+                      <TooltipContent hideWhenDetached>
+                        <p>Delete</p>
+                      </TooltipContent>
+                    </Tooltip>
                   </div>
                 </SidebarMenuItem>
               ))}

--- a/apps/web/src/components/chat/chat-toggles.tsx
+++ b/apps/web/src/components/chat/chat-toggles.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback } from "react";
 import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
 import { Icon } from "@iconify/react";
 import { usePersisted } from "~/hooks/usePersisted";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 export interface ToggleState {
   search: boolean;
@@ -29,9 +30,16 @@ const ChatToggles = memo(function ChatToggles() {
       value={groupValue}
       onValueChange={handleChange}
     >
-      <ToggleGroupItem value="search" size="default">
-        <Icon icon="lucide:globe" className="bg-transparent" />
-      </ToggleGroupItem>
+      <Tooltip>
+        <TooltipTrigger>
+          <ToggleGroupItem value="search" size="default">
+            <Icon icon="lucide:globe" className="bg-transparent" />
+          </ToggleGroupItem>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Search</p>
+        </TooltipContent>
+      </Tooltip>
     </ToggleGroup>
   );
 });

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -6,7 +6,7 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cn } from "~/lib/utils";
 
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = 700,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (


### PR DESCRIPTION
### TL;DR

Added tooltips to chat sidebar items and action buttons to improve UI accessibility.

### What changed?

- Added tooltips to chat titles in the sidebar that show the full title when truncated
- Added tooltips to action buttons (Pin, Unpin, Delete) in the sidebar
- Added a tooltip to the Search toggle button
- Changed the default tooltip delay duration from 0 to 700ms for better user experience

### How to test?

1. Hover over truncated chat titles in the sidebar to see the full title in a tooltip
2. Hover over the Pin/Unpin and Delete buttons to see their respective tooltips
3. Hover over the Search toggle button to see its tooltip
4. Verify that tooltips appear after the configured delay (700ms)

### Why make this change?

Improves user experience by providing context for truncated text and clarifying the purpose of icon-only buttons. This enhances accessibility and makes the interface more intuitive, especially for new users who might not immediately understand what each icon represents.