### PR TITLE
feat(web): add asChild prop to TooltipTrigger components

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -87,7 +87,7 @@ export function AppSidebar() {
                         params={{ chatId: chat._id }}
                       >
                         <Tooltip>
-                          <TooltipTrigger className="truncate">
+                          <TooltipTrigger className="truncate" asChild>
                             <span className="block truncate max-w-full">
                               {chat.title}
                             </span>
@@ -100,7 +100,7 @@ export function AppSidebar() {
                     </SidebarMenuButton>
                     <div className="hidden absolute right-1 top-1.5 z-10 group-hover/item:flex flex-row gap-1 items-center group-hover/item:bg-sidebar-accent">
                       <Tooltip>
-                        <TooltipTrigger>
+                        <TooltipTrigger asChild>
                           <SidebarMenuAction
                             showOnHover
                             onClick={async (e) => {
@@ -121,7 +121,7 @@ export function AppSidebar() {
                         </TooltipContent>
                       </Tooltip>
                       <Tooltip>
-                        <TooltipTrigger>
+                        <TooltipTrigger asChild>
                           <SidebarMenuAction
                             showOnHover
                             onClick={async (e) => {
@@ -167,7 +167,7 @@ export function AppSidebar() {
                       params={{ chatId: chat._id }}
                     >
                       <Tooltip>
-                        <TooltipTrigger className="truncate">
+                        <TooltipTrigger className="truncate" asChild>
                           <span className="block truncate max-w-full">
                             {chat.title}
                           </span>
@@ -180,7 +180,7 @@ export function AppSidebar() {
                   </SidebarMenuButton>
                   <div className="hidden absolute right-1 top-1.5 z-10 group-hover/item:flex flex-row gap-1 items-center group-hover/item:bg-sidebar-accent">
                     <Tooltip>
-                      <TooltipTrigger>
+                      <TooltipTrigger asChild>
                         <SidebarMenuAction
                           showOnHover
                           onClick={async (e) => {
@@ -201,7 +201,7 @@ export function AppSidebar() {
                       </TooltipContent>
                     </Tooltip>
                     <Tooltip>
-                      <TooltipTrigger>
+                      <TooltipTrigger asChild>
                         <SidebarMenuAction
                           showOnHover
                           onClick={async (e) => {

--- a/apps/web/src/components/chat/chat-toggles.tsx
+++ b/apps/web/src/components/chat/chat-toggles.tsx
@@ -31,7 +31,7 @@ const ChatToggles = memo(function ChatToggles() {
       onValueChange={handleChange}
     >
       <Tooltip>
-        <TooltipTrigger>
+        <TooltipTrigger asChild>
           <ToggleGroupItem value="search" size="default">
             <Icon icon="lucide:globe" className="bg-transparent" />
           </ToggleGroupItem>


### PR DESCRIPTION
### TL;DR

Added `asChild` prop to all `TooltipTrigger` components in the sidebar and chat toggles.

### What changed?

- Added the `asChild` prop to all `TooltipTrigger` components in the application sidebar and chat toggles
- This modification affects tooltip behavior for chat items, edit/delete actions, and search toggle

### How to test?

1. Navigate to the sidebar and hover over chat items to verify tooltips appear correctly
2. Hover over edit and delete buttons to ensure tooltips display properly
3. Check the search toggle in the chat interface to confirm its tooltip works as expected

### Why make this change?

The `asChild` prop allows the `TooltipTrigger` component to properly adopt the child element as the trigger instead of wrapping it in an additional element. This improves accessibility and prevents potential DOM nesting issues, ensuring tooltips are correctly attached to their intended trigger elements.