### PR TITLE
fix(web): disable icon to prevent flickering

### DIFF
--- a/apps/web/src/components/blocks.tsx
+++ b/apps/web/src/components/blocks.tsx
@@ -231,12 +231,13 @@ function CodeBlock({ token }: { token: Tokens.Code }) {
     >
       <div className="flex justify-between border-b border-gray-200 px-2 py-2 bg-gray-50">
         <div className="flex gap-x-1 items-center">
-          {token.lang && (
+          {/* TODO: Move icon state to prevent flickering from re-rendering */}
+          {/* {token.lang && (
             <Icon
               icon={langIcon(highlightedLang)}
               className="h-4 w-4 bg-transparent"
             />
-          )}
+          )} */}
           <span className="text-gray-500 text-sm">{highlightedLang}</span>
         </div>
         <button


### PR DESCRIPTION
### TL;DR

Commented out the language icon in the code block component to prevent flickering.

### What changed?

- Commented out the language icon that appears next to the language name in code blocks
- Added a TODO comment explaining that the icon state should be moved to prevent flickering from re-rendering

### How to test?

1. Navigate to a page with code blocks
2. Verify that only the language name appears in the header of code blocks (without an icon)
3. Confirm that there is no flickering when interacting with code blocks

### Why make this change?

The language icon was causing UI flickering when the component re-rendered. This is a temporary fix while a more permanent solution (moving the icon state) is being developed.