### PR TITLE
feat(web): abort

### DIFF
--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -16,6 +16,7 @@ interface ChatInputProps {
   sessionToken: string;
   disabled: boolean;
   addUserMessage: (message: string) => void;
+  onStop: () => void;
 }
 
 const ChatInput = memo(function ChatInput({
@@ -23,6 +24,7 @@ const ChatInput = memo(function ChatInput({
   sessionToken,
   disabled,
   addUserMessage,
+  onStop,
 }: ChatInputProps) {
   const navigate = useNavigate();
   const createChat = useMutation(api.functions.chat.createChat);
@@ -118,18 +120,25 @@ const ChatInput = memo(function ChatInput({
             disabled={disabled}
             onKeyDown={handleKeyDown}
           />
-          <Button
-            type="button"
-            disabled={isDisabled()}
-            onClick={handleSendClick}
-            className={`${isDisabled() && "cursor-not-allowed"} h-full w-12`}
-          >
-            {disabled ? (
-              <div className="w-4 h-4 border-2 border-black border-t-transparent rounded-full animate-spin" />
-            ) : (
+          {disabled ? (
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={onStop}
+              className="h-full w-12 flex items-center justify-center"
+            >
+              <div className="w-4 h-4 bg-foreground" />
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              disabled={isDisabled()}
+              onClick={handleSendClick}
+              className={`${isDisabled() && "cursor-not-allowed"} h-full w-12`}
+            >
               <ArrowUpIcon className="w-4 h-4" />
-            )}
-          </Button>
+            </Button>
+          )}
         </div>
         <ChatOptions />
       </div>


### PR DESCRIPTION
### TL;DR

Added the ability to stop AI message generation mid-stream with an abort controller.

### What changed?

- Added a new `getMessageStatus` query to check if a message has been aborted
- Implemented an abort controller in the chat view to handle stopping message generation
- Added a stop button in the chat input that replaces the send button during streaming
- Updated the server route to check for aborted status during streaming and handle abort signals
- Added proper session token validation for message operations
- Enhanced error handling to differentiate between normal errors and abort actions

### How to test?

1. Start a conversation and send a message to the AI
2. While the AI is generating a response, click the stop button (square icon)
3. Verify that the message generation stops immediately
4. Check that the message is properly marked as "aborted" in the database
5. Ensure you can continue the conversation after stopping a response

### Why make this change?

This feature improves the user experience by allowing users to cancel AI responses that are taking too long or are not relevant to their needs. It also helps conserve API usage and reduces waiting time when users realize they don't need the full response.