### PR TITLE
fix(web): missing messages

### DIFF
--- a/apps/web/convex/functions/chat.ts
+++ b/apps/web/convex/functions/chat.ts
@@ -3,6 +3,14 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { mutation, query } from "../_generated/server";
 
+export const checkChatExists = query({
+  args: { chatId: v.id("chat") },
+  handler: async (ctx, args) => {
+    const chat = await ctx.db.get(args.chatId);
+    return !!chat;
+  },
+});
+
 export const getUserChats = query({
   args: { sessionToken: v.string() },
   handler: async (ctx, args) => {

--- a/apps/web/src/components/not-found.tsx
+++ b/apps/web/src/components/not-found.tsx
@@ -1,3 +1,38 @@
+import { Link } from "@tanstack/react-router";
+
 export function NotFound() {
-  return <div>Stupid not found</div>;
+  return (
+    <section className="bg-background font-sans min-h-screen flex items-center justify-center">
+      <div className="container mx-auto">
+        <div className="flex justify-center">
+          <div className="w-full sm:w-10/12 md:w-8/12 text-center">
+            <div
+              className="bg-[url(https://cdn.dribbble.com/users/285475/screenshots/2083086/dribbble_1.gif)] h-[250px] sm:h-[350px] md:h-[400px] bg-center bg-no-repeat bg-contain"
+              aria-hidden="true"
+            >
+              <h1 className="text-center text-foreground text-6xl sm:text-7xl md:text-8xl pt-6 sm:pt-8">
+                OpenYap
+              </h1>
+            </div>
+
+            <div className="mt-[-50px]">
+              <h3 className="text-2xl text-foreground sm:text-3xl font-bold mb-4">
+                Look like you're lost
+              </h3>
+              <p className="mb-6 text-foreground sm:mb-5">
+                The conversation you were looking for could not be found.
+              </p>
+
+              <Link
+                to="/"
+                className="my-5 bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2 rounded-md"
+              >
+                Start a new chat
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/apps/web/src/routes/api/chat.ts
+++ b/apps/web/src/routes/api/chat.ts
@@ -229,7 +229,7 @@ export const ServerRoute = createServerFileRoute("/api/chat").methods({
                     ),
                   }
                 : undefined;
-            void updateAiMessage({
+            await updateAiMessage({
               messageId,
               content: contentBuffer,
               reasoning: completedReasoning,
@@ -252,7 +252,7 @@ export const ServerRoute = createServerFileRoute("/api/chat").methods({
                     ),
                   }
                 : undefined;
-            void updateAiMessage({
+            await updateAiMessage({
               messageId,
               content: contentBuffer,
               reasoning: completedReasoning,
@@ -285,7 +285,7 @@ export const ServerRoute = createServerFileRoute("/api/chat").methods({
                   ),
                 }
               : undefined;
-          void updateAiMessage({
+          await updateAiMessage({
             messageId,
             content: contentBuffer,
             reasoning: completedReasoning,
@@ -316,7 +316,7 @@ export const ServerRoute = createServerFileRoute("/api/chat").methods({
                     ),
                   }
                 : undefined;
-            void updateAiMessage({
+            await updateAiMessage({
               messageId,
               content: contentBuffer,
               reasoning: completedReasoning,

--- a/apps/web/src/routes/chat/$chatId.tsx
+++ b/apps/web/src/routes/chat/$chatId.tsx
@@ -1,5 +1,29 @@
+import { notFound } from "@tanstack/react-router";
+import { convexQuery } from "@convex-dev/react-query";
+import type { Id } from "convex/_generated/dataModel";
+import { api } from "~/lib/db/server";
+import { isConvexId } from "~/lib/db/utils";
 import { ChatView } from "~/components/chat-view";
+import { NotFound } from "~/components/not-found";
 
 export const Route = createFileRoute({
+  loader: async ({ params, context }) => {
+    if (!isConvexId(params.chatId)) {
+      return notFound();
+    }
+
+    const chatExists = await context.queryClient.fetchQuery(
+      convexQuery(api.functions.chat.checkChatExists, {
+        chatId: params.chatId as Id<"chat">,
+      }),
+    );
+
+    if (!chatExists) {
+      return notFound();
+    }
+
+    return { chatExists };
+  },
   component: ChatView,
+  notFoundComponent: () => <NotFound />,
 });


### PR DESCRIPTION
### TL;DR

Added chat existence validation and improved the 404 page for non-existent chats.

### What changed?

- Added a new `checkChatExists` query function to verify if a chat exists
- Enhanced the `NotFound` component with a proper UI instead of the placeholder text
- Updated the chat route to validate chat IDs and show the not found page for invalid chats
- Fixed potential race conditions by changing `void updateAiMessage` to `await updateAiMessage` in the chat API

### How to test?

1. Try to navigate to a non-existent chat URL (e.g., `/chat/invalid_id` or a valid-looking but non-existent chat ID)
2. Verify the new not found page appears with the "Start a new chat" button
3. Click the button to ensure it redirects to the home page
4. Test that valid chat IDs still load properly

### Why make this change?

This improves the user experience by providing proper validation and a helpful error page when users attempt to access non-existent chats. The previous implementation showed a basic "Stupid not found" message, which wasn't user-friendly. Additionally, the API changes ensure message updates are properly awaited, preventing potential race conditions.