### PR TITLE
fix(web): hide last assistant message during streaming

### DIFF
--- a/apps/web/src/components/chat-view.tsx
+++ b/apps/web/src/components/chat-view.tsx
@@ -273,10 +273,11 @@ export function ChatView() {
               <h1 className="text-2xl">Where should we begin?</h1>
             </div>
           ) : (
-            messages.map((m) => {
+            messages.map((m, index) => {
               if (
                 m.role === "assistant" &&
-                (m.status === "generating" || m.status === "reasoning")
+                status === "streaming" &&
+                index === messages.length - 1
               ) {
                 return null;
               }


### PR DESCRIPTION
### TL;DR

Fixed message rendering during streaming to prevent duplicate messages.

### What changed?

Modified the message rendering logic in the chat view to prevent displaying messages that are currently being streamed. Instead of checking the message status (`generating` or `reasoning`), the code now checks if the current message is the last one in the array and if the overall status is `streaming`.

### How to test?

1. Start a conversation with the AI
2. Observe the message streaming behavior
3. Verify that messages don't appear duplicated during streaming
4. Confirm that completed messages display correctly

### Why make this change?

The previous implementation was causing issues where messages might be displayed twice during the streaming process - once in their partial state and once in the streaming component. This change ensures that only one instance of a message appears during streaming, improving the user experience and preventing visual confusion.