### PR TITLE
refactor(web): extract search toggle key to constant

### DIFF
--- a/apps/web/src/components/chat-view.tsx
+++ b/apps/web/src/components/chat-view.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery } from "convex/react";
 import { useCallback, useEffect, useState } from "react";
 import { ChatInput } from "~/components/chat/chat-input";
 import { MODEL_PERSIST_KEY } from "~/components/chat/model-selector";
+import { SEARCH_TOGGLE_KEY } from "~/components/chat/chat-toggles";
 import type {
   ChatMessage,
   MessageReasoning,
@@ -33,7 +34,7 @@ export function ChatView() {
     useState<AbortController | null>(null);
 
   const { value: searchEnabled, reset: resetSearchToggle } =
-    usePersisted<boolean>("search-toggle", false);
+    usePersisted<boolean>(SEARCH_TOGGLE_KEY, false);
 
   const updateChat = useMutation(api.functions.chat.updateChat);
   const updateUserMessage = useMutation(

--- a/apps/web/src/components/chat/chat-toggles.tsx
+++ b/apps/web/src/components/chat/chat-toggles.tsx
@@ -4,15 +4,16 @@ import { Toggle } from "~/components/ui/toggle";
 import { usePersisted } from "~/hooks/usePersisted";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
+export const SEARCH_TOGGLE_KEY = "search-toggle";
+
 const ChatToggles = memo(function ChatToggles() {
   const { value: searchEnabled, set: setSearchEnabled } = usePersisted<boolean>(
-    "search-toggle",
+    SEARCH_TOGGLE_KEY,
     false
   );
 
   const handleToggle = useCallback(
     (pressed: boolean) => {
-      console.log("[ChatToggles] handleToggle", pressed);
       setSearchEnabled(pressed);
     },
     [setSearchEnabled]


### PR DESCRIPTION
### TL;DR

Extracted the search toggle key into a constant and removed a console log statement.

### What changed?

- Created a new constant `SEARCH_TOGGLE_KEY` with the value "search-toggle" in the chat-toggles.tsx file
- Exported this constant and imported it in chat-view.tsx
- Replaced string literals with the new constant in both files
- Removed a console.log statement from the handleToggle function in ChatToggles component

### How to test?

1. Verify that the search toggle functionality works as before
2. Check that toggling the search option correctly persists the setting between sessions
3. Confirm that no console logs appear when toggling the search option

### Why make this change?

This change improves code maintainability by centralizing the search toggle key in a single location, making it easier to update if needed. It also removes unnecessary console logging that was likely used for debugging purposes but is no longer needed in production code.