### PR TITLE
fix(web): adjust chat layout and hide messages with generating/reasoning status

### DIFF
--- a/apps/web/src/components/chat-view.tsx
+++ b/apps/web/src/components/chat-view.tsx
@@ -268,7 +268,7 @@ export function ChatView() {
   return (
     <div className="flex h-full flex-col bg-background">
       <div className="mb-16 flex-1 overflow-y-auto p-4">
-        <div className="mx-auto h-full max-w-4xl space-y-4">
+        <div className="mx-auto h-full max-w-3xl space-y-4">
           {messages.length === 0 && !isLoading ? (
             <div className="flex h-full items-center justify-center text-foreground">
               <h1 className="text-2xl">Where should we begin?</h1>
@@ -276,9 +276,11 @@ export function ChatView() {
           ) : (
             messages.map((m, index) => {
               if (
-                m.role === "assistant" &&
-                status === "streaming" &&
-                index === messages.length - 1
+                (m.role === "assistant" &&
+                  status === "streaming" &&
+                  index === messages.length - 1) ||
+                m.status === "generating" ||
+                m.status === "reasoning"
               ) {
                 return null;
               }
@@ -298,7 +300,7 @@ export function ChatView() {
                       )}
                     </div>
                   ) : (
-                    <div className="max-w-[70%] text-foreground">
+                    <div className="max-w-full text-foreground">
                       <Message data={m} />
                     </div>
                   )}
@@ -308,7 +310,7 @@ export function ChatView() {
           )}
           {showOptimisticMessage && (
             <div className="flex justify-start">
-              <div className="max-w-[70%] text-foreground">
+              <div className="max-w-full text-foreground">
                 <Message data={streamingMessage} />
               </div>
             </div>


### PR DESCRIPTION
### TL;DR

Improved chat UI by adjusting layout widths and fixing message display logic.

### What changed?

- Reduced the maximum width of the chat container from `max-w-4xl` to `max-w-3xl` for better readability
- Expanded message width from `max-w-[70%]` to `max-w-full` for both regular and optimistic messages
- Enhanced message display logic to hide messages with status "generating" or "reasoning" in addition to streaming assistant messages

### How to test?

1. Open the chat interface and verify the narrower chat container width
2. Send messages and check that they now use the full available width
3. Test with streaming responses to ensure messages with "generating" or "reasoning" status are properly hidden

### Why make this change?

These adjustments improve the readability of the chat interface by providing a more focused reading width while allowing messages to use the full available space. The enhanced message display logic ensures a smoother experience by properly handling different message states during generation.