### PR TITLE
feat(web): added theme provider

### DIFF
--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -1,0 +1,91 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "dark" | "light" | "system";
+
+interface ThemeProviderProps {
+  readonly children: React.ReactNode;
+  readonly defaultTheme?: Theme;
+  readonly storageKey?: string;
+}
+
+interface ThemeProviderState {
+  readonly theme: Theme;
+  readonly resolvedTheme: Exclude<Theme, "system">;
+  readonly setTheme: (theme: Theme) => void;
+}
+
+const initialState: ThemeProviderState = {
+  theme: "system",
+  resolvedTheme: "light",
+  setTheme: () => undefined,
+};
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+  storageKey = "ui-theme",
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === "undefined") return defaultTheme;
+    return (localStorage.getItem(storageKey) as Theme) ?? defaultTheme;
+  });
+
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">(() => {
+    if (typeof window === "undefined") {
+      return defaultTheme === "system"
+        ? "light"
+        : (defaultTheme as "light" | "dark");
+    }
+    if (theme === "system") {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+    }
+    return theme;
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const applyTheme = () => {
+      const nextResolved =
+        theme === "system" ? (mediaQuery.matches ? "dark" : "light") : theme;
+      setResolvedTheme(nextResolved);
+      root.classList.remove("light", "dark");
+      root.classList.add(nextResolved);
+    };
+
+    applyTheme();
+
+    if (theme === "system") {
+      mediaQuery.addEventListener("change", applyTheme);
+      return () => mediaQuery.removeEventListener("change", applyTheme);
+    }
+  }, [theme]);
+
+  const value: ThemeProviderState = {
+    theme,
+    resolvedTheme,
+    setTheme: (newTheme) => {
+      localStorage.setItem(storageKey, newTheme);
+      setTheme(newTheme);
+    },
+  };
+
+  return (
+    <ThemeProviderContext.Provider value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeProviderState {
+  const context = useContext(ThemeProviderContext);
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
### TL;DR

Added a theme provider component to support light, dark, and system themes.

### What changed?

Created a new `theme-provider.tsx` file that implements:
- A React context for theme management
- Support for "light", "dark", and "system" themes
- Theme persistence using localStorage
- Automatic detection of system preferences
- A `useTheme` hook for consuming theme information

### How to test?

1. Import and wrap your application with the `ThemeProvider`:
   ```tsx
   import { ThemeProvider } from "@/components/theme-provider";
   
   function App() {
     return (
       <ThemeProvider>
         <YourApp />
       </ThemeProvider>
     );
   }
   ```

2. Use the `useTheme` hook in components to access and change the theme:
   ```tsx
   import { useTheme } from "@/components/theme-provider";
   
   function ThemeToggle() {
     const { theme, setTheme } = useTheme();
     
     return (
       <button onClick={() => setTheme(theme === "dark" ? "light" : "dark")}>
         Toggle theme
       </button>
     );
   }
   ```

3. Verify that:
   - The theme persists across page refreshes
   - System theme changes are detected when using "system" mode
   - The appropriate CSS classes are applied to the document root

### Why make this change?

To provide a consistent theming solution that supports user preferences and system settings. This implementation allows for seamless switching between light and dark modes while respecting the user's system preferences when set to "system" mode.