### PR TITLE
feat(web): add dark mode support to UI components

### DIFF
--- a/apps/web/src/components/auth/profile-card.tsx
+++ b/apps/web/src/components/auth/profile-card.tsx
@@ -48,7 +48,7 @@ export function ProfileCard() {
 
   if (session.data?.user) {
     return (
-      <div className="flex h-12 items-center justify-between rounded border border-gray-200 px-2">
+      <div className="flex h-12 items-center justify-between rounded border border-border px-2 dark:border-border">
         <div className="flex items-center gap-2">
           <Avatar>
             <AvatarImage src={session.data.user.image ?? ""} />

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "~/components/ui/sidebar";
+import { ThemeProvider } from "~/components/theme-provider";
 
 import appCss from "~/styles.css?url";
 
@@ -62,13 +63,15 @@ function RootDocument({ children }: { readonly children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        <SidebarProvider>
-          <div className="fixed top-0 left-0 z-50 p-4">
-            <SidebarTrigger />
-          </div>
-          <AppSidebar />
-          <SidebarInset>{children}</SidebarInset>
-        </SidebarProvider>
+        <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
+          <SidebarProvider>
+            <div className="fixed top-0 left-0 z-50 p-4">
+              <SidebarTrigger />
+            </div>
+            <AppSidebar />
+            <SidebarInset>{children}</SidebarInset>
+          </SidebarProvider>
+        </ThemeProvider>
         <Scripts />
         <ReactQueryDevtools initialIsOpen={false} />
         <TanStackRouterDevtools initialIsOpen={false} />


### PR DESCRIPTION
### TL;DR

Added dark mode support to the application by implementing a ThemeProvider and updating component styling to use theme-aware color variables.

### What changed?

- Added a `ThemeProvider` component to the root layout that manages theme state
- Updated syntax highlighting in code blocks to use `atomDark` theme for dark mode
- Modified CSS classes throughout the application to use theme-aware color tokens:
  - Changed hardcoded color values (like `text-gray-800`) to semantic color tokens (like `text-foreground`)
  - Updated border colors to use `border-border` instead of `border-gray-200`
  - Updated background colors to use `bg-card`, `bg-muted`, and `bg-background`
  - Updated text colors to use `text-foreground` and `text-muted-foreground`
- Added theme detection logic to conditionally render appropriate styles based on the current theme

### How to test?

1. Run the application and verify the default theme loads correctly
2. Toggle between light and dark modes to ensure all components render properly in both themes
3. Check that code blocks, tables, text, and other UI elements maintain proper contrast in both themes
4. Verify that the theme preference is saved and persists between page refreshes

### Why make this change?

This change improves accessibility and user experience by providing a dark mode option, which reduces eye strain in low-light environments and accommodates user preferences. The implementation uses semantic color tokens rather than hardcoded values, making the codebase more maintainable and consistent across themes.