### PR TITLE
feat(web): add reasoning effort selector for supported models

### DIFF
--- a/apps/web/src/components/chat/chat-options.tsx
+++ b/apps/web/src/components/chat/chat-options.tsx
@@ -1,11 +1,13 @@
 import { memo } from "react";
 import { ChatToggles } from "~/components/chat/chat-toggles";
 import { ModelSelector } from "~/components/chat/model-selector";
+import { ReasoningEffortSelector } from "~/components/chat/reasoning-effort-selector";
 
 const ChatOptions = memo(function ChatOptions() {
   return (
     <div className="flex items-center gap-2">
       <ModelSelector />
+      <ReasoningEffortSelector />
       <ChatToggles />
     </div>
   );

--- a/apps/web/src/components/chat/model-selector.tsx
+++ b/apps/web/src/components/chat/model-selector.tsx
@@ -19,27 +19,25 @@ const ModelSelector = memo(function ModelSelector() {
     (value: string) => {
       setSelectedModelId(Number.parseInt(value));
     },
-    [setSelectedModelId],
+    [setSelectedModelId]
   );
 
   return (
-    <div className="flex justify-start">
-      <Select
-        value={selectedModelId.toString()}
-        onValueChange={handleModelChange}
-      >
-        <SelectTrigger className="w-[200px]">
-          <SelectValue placeholder="Select model" />
-        </SelectTrigger>
-        <SelectContent>
-          {models.map((model) => (
-            <SelectItem key={model.id} value={model.id.toString()}>
-              {model.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <Select
+      value={selectedModelId.toString()}
+      onValueChange={handleModelChange}
+    >
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder="Select model" />
+      </SelectTrigger>
+      <SelectContent>
+        {models.map((model) => (
+          <SelectItem key={model.id} value={model.id.toString()}>
+            {model.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 });
 

--- a/apps/web/src/components/chat/reasoning-effort-selector.tsx
+++ b/apps/web/src/components/chat/reasoning-effort-selector.tsx
@@ -1,0 +1,74 @@
+import { memo, useCallback } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+import { usePersisted } from "~/hooks/use-persisted";
+import {
+  getDefaultModel,
+  getModelById,
+  ReasoningEffort,
+  type EffortLabel,
+} from "~/lib/models";
+import { MODEL_PERSIST_KEY } from "~/components/chat/model-selector";
+
+export const REASONING_EFFORT_PERSIST_KEY = "selected-reasoning-effort";
+
+const effortOptions: EffortLabel[] = [
+  ReasoningEffort.LOW,
+  ReasoningEffort.MEDIUM,
+  ReasoningEffort.HIGH,
+];
+
+const ReasoningEffortSelector = memo(function ReasoningEffortSelector() {
+  const { value: selectedModelId } = usePersisted<number>(
+    MODEL_PERSIST_KEY,
+    getDefaultModel().id
+  );
+  const { value: selectedEffort, set: setSelectedEffort } =
+    usePersisted<EffortLabel>(
+      REASONING_EFFORT_PERSIST_KEY,
+      ReasoningEffort.LOW
+    );
+
+  const selectedModel = getModelById(selectedModelId);
+
+  const handleEffortChange = useCallback(
+    (value: string) => {
+      setSelectedEffort(value as EffortLabel);
+    },
+    [setSelectedEffort]
+  );
+
+  if (!selectedModel || !selectedModel.reasoningEffort) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Select value={selectedEffort} onValueChange={handleEffortChange}>
+          <SelectTrigger className="w-[120px]">
+            <SelectValue placeholder="Effort" />
+          </SelectTrigger>
+          <SelectContent>
+            {effortOptions.map((effort) => (
+              <SelectItem key={effort} value={effort}>
+                {effort}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </TooltipTrigger>
+      <TooltipContent>Reasoning effort</TooltipContent>
+    </Tooltip>
+  );
+});
+
+export { ReasoningEffortSelector };

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -4,8 +4,18 @@ export interface Model {
   readonly modelId: string;
   readonly provider: string;
   readonly premium: boolean;
+  readonly reasoningEffort: boolean;
   readonly isDefault?: boolean;
 }
+
+export const ReasoningEffort = {
+  LOW: "Low",
+  MEDIUM: "Medium",
+  HIGH: "High",
+} as const;
+
+export type EffortKey = keyof typeof ReasoningEffort;
+export type EffortLabel = (typeof ReasoningEffort)[EffortKey];
 
 export const getSystemPrompt = (model: Model, userName: string) => {
   const modelName = model.name;
@@ -65,6 +75,7 @@ export const models: readonly Model[] = [
     modelId: "google/gemini-2.0-flash-lite-001",
     provider: "openrouter",
     premium: false,
+    reasoningEffort: false,
     isDefault: true,
   },
   {
@@ -73,6 +84,7 @@ export const models: readonly Model[] = [
     modelId: "google/gemini-2.0-flash-001",
     provider: "openrouter",
     premium: false,
+    reasoningEffort: false,
   },
   {
     id: 3,
@@ -80,6 +92,7 @@ export const models: readonly Model[] = [
     modelId: "google/gemini-2.5-flash-lite-preview-06-17",
     provider: "openrouter",
     premium: false,
+    reasoningEffort: false,
     isDefault: false,
   },
   {
@@ -88,6 +101,7 @@ export const models: readonly Model[] = [
     modelId: "google/gemini-2.5-flash-preview-05-20",
     provider: "openrouter",
     premium: false,
+    reasoningEffort: false,
   },
   {
     id: 5,
@@ -95,6 +109,7 @@ export const models: readonly Model[] = [
     modelId: "google/gemini-2.5-pro-preview",
     provider: "openrouter",
     premium: false,
+    reasoningEffort: true,
   },
   {
     id: 6,
@@ -102,6 +117,7 @@ export const models: readonly Model[] = [
     modelId: "anthropic/claude-sonnet-4",
     provider: "openrouter",
     premium: true,
+    reasoningEffort: false,
   },
   {
     id: 7,
@@ -109,5 +125,6 @@ export const models: readonly Model[] = [
     modelId: "openai/gpt-4.1",
     provider: "openrouter",
     premium: false,
+    reasoningEffort: false,
   },
 ] as const;


### PR DESCRIPTION
### TL;DR

Added a reasoning effort selector for models that support this feature.

### What changed?

- Added a new `ReasoningEffortSelector` component that allows users to choose between Low, Medium, and High reasoning effort levels
- Updated the `Model` interface to include a `reasoningEffort` boolean flag
- Added the `ReasoningEffort` constant with three levels (Low, Medium, High)
- Set the `reasoningEffort` flag to `true` for the Gemini 2.5 Pro model
- Integrated the selector into the chat options UI
- Removed unnecessary wrapper div from the ModelSelector component

### How to test?

1. Open the chat interface
2. Select "Gemini 2.5 Pro" from the model dropdown
3. Verify that a new "Reasoning effort" dropdown appears with Low, Medium, and High options
4. Confirm that the reasoning effort selector is not visible when other models are selected
5. Verify that the selected effort level persists between sessions

### Why make this change?

This change allows users to control the reasoning depth for models that support variable reasoning effort. The Gemini 2.5 Pro model can adjust its reasoning approach based on the selected effort level, providing users with more control over the model's response quality and processing time.