### PR TITLE
feat(web): add o4-mini model to available models list

### DIFF
--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -127,4 +127,12 @@ export const models: readonly Model[] = [
     premium: false,
     reasoningEffort: false,
   },
+  {
+    id: 8,
+    name: "o4-mini",
+    modelId: "openai/o4-mini",
+    provider: "openrouter",
+    premium: false,
+    reasoningEffort: true,
+  },
 ] as const;


### PR DESCRIPTION
### TL;DR

Added OpenAI's o4-mini model to the available models list.

### What changed?

Added a new model entry for "o4-mini" to the models array with the following configuration:
- id: 8
- name: "o4-mini"
- modelId: "openai/o4-mini"
- provider: "openrouter"
- premium: false
- reasoningEffort: true

### How to test?

1. Run the application and verify that o4-mini appears in the model selection dropdown
2. Select the o4-mini model and confirm it works properly with API requests
3. Verify that the model is correctly marked as non-premium but with reasoning effort enabled

### Why make this change?

To provide users access to OpenAI's new o4-mini model through the OpenRouter provider, expanding the available model options with a model that supports reasoning capabilities without requiring premium access.