### PR TITLE
feat(web): add reasoning selection

### DIFF
--- a/apps/web/convex/functions/message.ts
+++ b/apps/web/convex/functions/message.ts
@@ -96,7 +96,7 @@ export const createAiMessage = mutation({
           completionTokens: 0,
           totalTokens: 0,
         },
-      },
+      }
     );
 
     return messageId;
@@ -112,7 +112,8 @@ export const updateAiMessage = mutation({
         text: v.string(),
         details: v.array(v.object({ text: v.string() })),
         duration: v.number(),
-      }),
+        reasoningEffort: v.optional(v.string()),
+      })
     ),
     status: v.optional(v.string()),
     sessionToken: v.string(),
@@ -123,7 +124,7 @@ export const updateAiMessage = mutation({
         promptTokens: v.number(),
         completionTokens: v.number(),
         totalTokens: v.number(),
-      }),
+      })
     ),
     historyEntry: v.optional(
       v.object({
@@ -135,7 +136,8 @@ export const updateAiMessage = mutation({
             text: v.string(),
             details: v.array(v.object({ text: v.string() })),
             duration: v.number(),
-          }),
+            reasoningEffort: v.optional(v.string()),
+          })
         ),
         provider: v.optional(v.string()),
         model: v.optional(v.string()),
@@ -144,9 +146,9 @@ export const updateAiMessage = mutation({
             promptTokens: v.number(),
             completionTokens: v.number(),
             totalTokens: v.number(),
-          }),
+          })
         ),
-      }),
+      })
     ),
   },
   handler: async (ctx, args) => {
@@ -204,7 +206,8 @@ export const createMessage = internalMutation({
         text: v.string(),
         details: v.array(v.object({ text: v.string() })),
         duration: v.number(),
-      }),
+        reasoningEffort: v.optional(v.string()),
+      })
     ),
     status: v.string(),
     error: v.optional(v.string()),
@@ -213,7 +216,7 @@ export const createMessage = internalMutation({
         promptTokens: v.number(),
         completionTokens: v.number(),
         totalTokens: v.number(),
-      }),
+      })
     ),
     tools: v.optional(v.array(v.any())),
     sources: v.optional(v.array(v.any())),
@@ -227,7 +230,8 @@ export const createMessage = internalMutation({
               text: v.string(),
               details: v.array(v.object({ text: v.string() })),
               duration: v.number(),
-            }),
+              reasoningEffort: v.optional(v.string()),
+            })
           ),
           provider: v.optional(v.string()),
           model: v.optional(v.string()),
@@ -236,14 +240,14 @@ export const createMessage = internalMutation({
               promptTokens: v.number(),
               completionTokens: v.number(),
               totalTokens: v.number(),
-            }),
+            })
           ),
           status: v.string(),
           error: v.optional(v.string()),
           tools: v.optional(v.array(v.any())),
           sources: v.optional(v.array(v.any())),
-        }),
-      ),
+        })
+      )
     ),
     webSearchResults: v.optional(v.any()),
     attachments: v.optional(v.array(v.id("attachment"))),
@@ -284,7 +288,8 @@ export const updateMessage = internalMutation({
         text: v.string(),
         details: v.array(v.object({ text: v.string() })),
         duration: v.number(),
-      }),
+        reasoningEffort: v.optional(v.string()),
+      })
     ),
     status: v.optional(v.string()),
     error: v.optional(v.string()),
@@ -293,7 +298,7 @@ export const updateMessage = internalMutation({
         promptTokens: v.number(),
         completionTokens: v.number(),
         totalTokens: v.number(),
-      }),
+      })
     ),
     tools: v.optional(v.array(v.any())),
     sources: v.optional(v.array(v.any())),
@@ -306,7 +311,8 @@ export const updateMessage = internalMutation({
             text: v.string(),
             details: v.array(v.object({ text: v.string() })),
             duration: v.number(),
-          }),
+            reasoningEffort: v.optional(v.string()),
+          })
         ),
         provider: v.optional(v.string()),
         model: v.optional(v.string()),
@@ -315,13 +321,13 @@ export const updateMessage = internalMutation({
             promptTokens: v.number(),
             completionTokens: v.number(),
             totalTokens: v.number(),
-          }),
+          })
         ),
         status: v.optional(v.string()),
         error: v.optional(v.string()),
         tools: v.optional(v.array(v.any())),
         sources: v.optional(v.array(v.any())),
-      }),
+      })
     ),
     webSearchResults: v.optional(v.any()),
     attachments: v.optional(v.array(v.id("attachment"))),

--- a/apps/web/convex/schema.ts
+++ b/apps/web/convex/schema.ts
@@ -14,7 +14,7 @@ export default defineSchema({
     visibility: v.union(
       v.literal("private"), // only owner + invited members
       v.literal("shared"), // anyone with link
-      v.literal("public"), // discoverable/searchable
+      v.literal("public") // discoverable/searchable
     ),
     // Token for sharing the chat
     shareToken: v.optional(v.string()),
@@ -73,10 +73,11 @@ export default defineSchema({
         details: v.array(
           v.object({
             text: v.string(),
-          }),
+          })
         ),
         duration: v.number(),
-      }),
+        reasoningEffort: v.optional(v.string()),
+      })
     ),
     // Metadata
     status: v.string(),
@@ -87,7 +88,7 @@ export default defineSchema({
         promptTokens: v.number(),
         completionTokens: v.number(),
         totalTokens: v.number(),
-      }),
+      })
     ),
     tools: v.optional(v.array(v.any())),
     sources: v.optional(v.array(v.any())),
@@ -106,10 +107,11 @@ export default defineSchema({
               details: v.array(
                 v.object({
                   text: v.string(),
-                }),
+                })
               ),
               duration: v.number(),
-            }),
+              reasoningEffort: v.optional(v.string()),
+            })
           ),
           // The provider and model used for THIS attempt
           provider: v.optional(v.string()),
@@ -120,7 +122,7 @@ export default defineSchema({
               promptTokens: v.number(),
               completionTokens: v.number(),
               totalTokens: v.number(),
-            }),
+            })
           ),
           // Metadata
           status: v.string(),
@@ -128,8 +130,8 @@ export default defineSchema({
           tools: v.optional(v.array(v.any())),
           sources: v.optional(v.array(v.any())),
           createdAt: v.string(),
-        }),
-      ),
+        })
+      )
     ),
 
     // Web search/RAG results (if any)
@@ -178,13 +180,13 @@ export default defineSchema({
             promptTokens: v.number(),
             completionTokens: v.number(),
             totalTokens: v.number(),
-          }),
+          })
         ),
         // When this version was created
         createdAt: v.string(),
         // Optional reason for the change (e.g., "user_retry", "initial_generation")
         reason: v.optional(v.string()),
-      }),
+      })
     ),
     // Order/index among siblings
     order: v.number(),
@@ -233,7 +235,7 @@ export default defineSchema({
         defaultModel: v.optional(v.string()),
         theme: v.optional(v.string()),
         language: v.optional(v.string()),
-      }),
+      })
     ),
     // Encrypted API keys for the user
     apiKeys: v.optional(v.object({})),

--- a/apps/web/src/components/chat/reasoning-effort-selector.tsx
+++ b/apps/web/src/components/chat/reasoning-effort-selector.tsx
@@ -31,12 +31,12 @@ const effortOptions: EffortLabel[] = [
 const ReasoningEffortSelector = memo(function ReasoningEffortSelector() {
   const { value: selectedModelId } = usePersisted<number>(
     MODEL_PERSIST_KEY,
-    getDefaultModel().id,
+    getDefaultModel().id
   );
   const { value: selectedEffort, set: setSelectedEffort } =
     usePersisted<EffortLabel>(
       REASONING_EFFORT_PERSIST_KEY,
-      ReasoningEffort.LOW,
+      ReasoningEffort.LOW
     );
 
   const selectedModel = getModelById(selectedModelId);
@@ -45,7 +45,7 @@ const ReasoningEffortSelector = memo(function ReasoningEffortSelector() {
     (value: string) => {
       setSelectedEffort(value as EffortLabel);
     },
-    [setSelectedEffort],
+    [setSelectedEffort]
   );
 
   if (!selectedModel || !selectedModel.reasoningEffort) return null;
@@ -60,7 +60,7 @@ const ReasoningEffortSelector = memo(function ReasoningEffortSelector() {
           <SelectContent>
             {effortOptions.map((effort) => (
               <SelectItem key={effort} value={effort}>
-                {effort}
+                {effort.charAt(0).toUpperCase() + effort.slice(1)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -9,9 +9,9 @@ export interface Model {
 }
 
 export const ReasoningEffort = {
-  LOW: "Low",
-  MEDIUM: "Medium",
-  HIGH: "High",
+  LOW: "low",
+  MEDIUM: "medium",
+  HIGH: "high",
 } as const;
 
 export type EffortKey = keyof typeof ReasoningEffort;


### PR DESCRIPTION
### TL;DR

Added support for configurable reasoning effort levels when generating AI responses.

### What changed?

- Added a new optional `reasoningEffort` field to message schemas in both database and API
- Updated the reasoning effort selector UI to properly capitalize displayed options
- Modified the chat API to pass reasoning effort settings to the AI provider
- Standardized reasoning effort values to lowercase strings ("low", "medium", "high")
- Integrated reasoning effort selection into the chat generation process

### How to test?

1. Open a chat and verify the reasoning effort selector is visible for models that support it
2. Select different reasoning effort levels (Low, Medium, High) and send messages
3. Observe that the AI responses reflect the selected reasoning effort level
4. Check that the reasoning effort is properly stored with the message

### Why make this change?

This change allows users to control how much effort the AI model puts into reasoning through complex problems. By offering different levels (low, medium, high), users can choose between faster responses with less detailed reasoning or more thorough analysis when needed. This provides more flexibility and control over the AI's response quality and depth.