### PR TITLE
feat(web): add copy message

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.513.0",
     "marked": "15.0.12",
+    "motion": "12.19.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-scan": "^0.3.4",

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -2,7 +2,7 @@ import { useParams } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import { useEffect } from "react";
 import { ChatInput } from "~/components/chat/chat-input";
-import { Message } from "~/components/chat/message";
+import { Message, StreamingAiMessage } from "~/components/chat/message";
 import { useChat } from "~/hooks/use-chat";
 import { useChatsList } from "~/hooks/use-chats-list";
 import { authClient } from "~/lib/auth/client";
@@ -69,7 +69,7 @@ export function ChatView() {
 
   return (
     <div className="flex h-full flex-col bg-background">
-      <div className="mb-16 flex-1 overflow-y-auto p-4">
+      <div className="mb-16 flex-1 p-4">
         <div className="mx-auto h-full max-w-3xl space-y-4">
           {messages.length === 0 && !isLoading ? (
             <div className="flex h-full items-center justify-center text-foreground">
@@ -87,34 +87,12 @@ export function ChatView() {
                 return null;
               }
               return (
-                <div
-                  key={m._id}
-                  className={`flex ${
-                    m.role === "user" ? "justify-end" : "justify-start"
-                  }`}
-                >
-                  {m.role === "user" ? (
-                    <div className="ml-auto max-w-[70%] rounded-lg border border-border bg-sidebar-accent px-4 py-2 text-sidebar-accent-foreground">
-                      <Message data={m} />
-                      {m.error && (
-                        <div className="text-red-500 text-xs">{m.error}</div>
-                      )}
-                    </div>
-                  ) : (
-                    <div className="max-w-full text-foreground">
-                      <Message data={m} />
-                    </div>
-                  )}
-                </div>
+                <Message key={m._id} data={m} />
               );
             })
           )}
           {showOptimisticMessage && (
-            <div className="flex justify-start">
-              <div className="max-w-full text-foreground">
-                <Message data={streamingMessage} />
-              </div>
-            </div>
+            <StreamingAiMessage data={streamingMessage} />
           )}
         </div>
       </div>

--- a/apps/web/src/components/chat/message.tsx
+++ b/apps/web/src/components/chat/message.tsx
@@ -4,9 +4,9 @@ import { memo, useMemo, useState } from "react";
 import { TokenBlock } from "~/components/chat/blocks";
 import type {
   ChatMessage,
+  StreamingMessage,
   MessageReasoning,
   MessageStatus,
-  StreamingMessage,
 } from "~/components/chat/types";
 import { AnimatedShinyText } from "~/components/ui/animated-shiny-text";
 import {
@@ -14,6 +14,10 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "~/components/ui/collapsible";
+import { cn } from "~/lib/utils";
+import { motion } from "motion/react";
+import { Button } from "../ui/button";
+import { useClipboardCopy } from "~/hooks/use-clipboard-copy";
 
 interface ReasoningCollapsibleProps {
   readonly reasoning: MessageReasoning;
@@ -25,43 +29,28 @@ function formatSeconds(duration: number) {
   return seconds.toFixed(0);
 }
 
-const ReasoningCollapsible = ({
-  reasoning,
-  status,
-}: ReasoningCollapsibleProps) => {
+const ReasoningCollapsible = memo(function ReasoningCollapsible({ reasoning, status }: ReasoningCollapsibleProps) {
   if (!reasoning) return null;
-
   const [reasoningOpen, setReasoningOpen] = useState(false);
   const reasoningHidden = reasoning.text.length === 0;
-
   const isReasoning = status === "reasoning";
   const reasoningTitle = `Thought ${reasoning.duration ? `for ${formatSeconds(reasoning.duration)} seconds` : ""}`;
 
   return (
-    <Collapsible
-      open={reasoningOpen}
-      onOpenChange={setReasoningOpen}
-      hidden={reasoningHidden}
-      className="space-y-2"
-    >
+    <Collapsible open={reasoningOpen} onOpenChange={setReasoningOpen} hidden={reasoningHidden} className="space-y-2">
       <CollapsibleTrigger>
-        {!isReasoning && (
+        {!isReasoning ? (
           <div className="flex cursor-pointer items-center gap-x-0.5 text-gray-500">
             {reasoningTitle}
-            {reasoningOpen ? (
-              <Icon
-                icon="lucide:chevron-down"
-                className="h-4 w-4 bg-transparent text-gray-500"
-              />
-            ) : (
-              <Icon
-                icon="lucide:chevron-right"
-                className="h-4 w-4 bg-transparent text-gray-500"
-              />
-            )}
+            <motion.span
+              animate={{ rotate: reasoningOpen ? 90 : 0 }}
+              transition={{ duration: 0.2 }}
+              style={{ display: "inline-flex" }}
+            >
+              <Icon icon="lucide:chevron-right" className="h-4 w-4 bg-transparent text-gray-500" />
+            </motion.span>
           </div>
-        )}
-        {isReasoning && (
+        ) : (
           <div className="flex cursor-pointer items-center gap-x-2">
             <AnimatedShinyText>Thinking</AnimatedShinyText>
           </div>
@@ -79,9 +68,9 @@ const ReasoningCollapsible = ({
                 <div className="w-[1px] flex-grow bg-gray-300" />
               </div>
               <div className="flex-grow">
-                {tokens.map((token) => {
-                  return <TokenBlock key={crypto.randomUUID()} token={token} />;
-                })}
+                {tokens.map((token) => (
+                  <TokenBlock key={crypto.randomUUID()} token={token} />
+                ))}
               </div>
             </div>
           );
@@ -89,10 +78,7 @@ const ReasoningCollapsible = ({
         {!isReasoning && (
           <div className="flex items-center gap-x-2 text-gray-500">
             <div className="flex w-4 shrink-0 justify-center">
-              <Icon
-                icon="lucide:circle-check"
-                className="h-4 w-4 bg-transparent text-gray-500"
-              />
+              <Icon icon="lucide:circle-check" className="h-4 w-4 bg-transparent text-gray-500" />
             </div>
             <span className="text-gray-500">Done</span>
           </div>
@@ -100,28 +86,65 @@ const ReasoningCollapsible = ({
       </CollapsibleContent>
     </Collapsible>
   );
-};
+});
+
+type MessageUnion = ChatMessage | StreamingMessage;
 
 interface MessageProps {
-  readonly data: ChatMessage | StreamingMessage;
+  readonly data: MessageUnion;
 }
 
-const MessageComponent = ({ data }: MessageProps) => {
-  const contentTokens = useMemo(
-    () => marked.lexer(data.content),
-    [data.content],
-  );
+const Message = memo(function Message({ data }: MessageProps) {
+  const { isCopied, copy } = useClipboardCopy();
+  const contentTokens = useMemo(() => marked.lexer(data.content), [data.content]);
+
+  const isUser = data.role === "user";
+  const isAssistant = data.role === "assistant";
+  const error = "error" in data && data.error ? data.error : null;
 
   return (
-    <div className="space-y-2">
-      <ReasoningCollapsible reasoning={data.reasoning} status={data.status} />
-      <div className="whitespace-pre-wrap break-words">
-        {contentTokens.map((token) => {
-          return <TokenBlock key={crypto.randomUUID()} token={token} />;
-        })}
+    <div className="w-full flex flex-col gap-y-2 group">
+      <div className={cn(
+        "px-4 py-2 space-y-2",
+        isUser && "rounded-lg border border-border bg-sidebar-accent text-sidebar-accent-foreground",
+        isAssistant && "text-foreground",
+        error && "border-red-500",
+      )}>
+        <ReasoningCollapsible reasoning={data.reasoning} status={data.status} />
+        <div className="whitespace-pre-wrap break-words">
+          {contentTokens.map((token) => (
+            <TokenBlock key={crypto.randomUUID()} token={token} />
+          ))}
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-x-2 min-h-[1.25rem] pl-4">
+        <div className="text-red-500 text-xs flex-1 min-w-0 truncate">
+          {error}
+        </div>
+        <div className="flex items-center gap-x-2 transition-opacity duration-200 opacity-0 group-hover:opacity-100">
+          <Button
+            type="button"
+            onMouseDown={() => copy(data.content)}
+            variant="ghost"
+            size="icon"
+            className="h-4 w-4"
+          >
+            <Icon
+              icon={isCopied ? "lucide:check" : "lucide:copy"}
+              className="bg-transparent text-gray-500"
+            />
+          </Button>
+        </div>
       </div>
     </div>
   );
-};
+});
 
-export const Message = memo(MessageComponent);
+interface StreamingAiMessageProps {
+  readonly data: StreamingMessage;
+}
+const StreamingAiMessage = memo(function StreamingAiMessage({ data }: StreamingAiMessageProps) {
+  return <Message data={data} />;
+});
+
+export { Message, StreamingAiMessage };

--- a/apps/web/src/hooks/use-clipboard-copy.ts
+++ b/apps/web/src/hooks/use-clipboard-copy.ts
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (error) {
+    console.error(error);
+    return false;
+  }
+}
+
+export function useClipboardCopy() {
+  const [isCopied, setIsCopied] = useState(false);
+
+  async function copy(text: string) {
+    setIsCopied(await copyToClipboard(text));
+    setTimeout(() => setIsCopied(false), 3000);
+  };
+
+  return { isCopied, copy };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       marked:
         specifier: 15.0.12
         version: 15.0.12
+      motion:
+        specifier: 12.19.1
+        version: 12.19.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -2749,6 +2752,20 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  framer-motion@12.19.1:
+    resolution: {integrity: sha512-nq9hwWAEKf4gzprbOZzKugLV5OVKF7zrNDY6UOVu+4D3ZgIkg8L9Jy6AMrpBM06fhbKJ6LEG6UY5+t7Eq6wNlg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -3321,6 +3338,26 @@ packages:
     resolution: {integrity: sha512-FeVc50FTfVVQnolk/WQT8MX+2WVcDnTGiq6Wo+/+lJ2ET1bRVi3HG3YlJUfqagNMc/kUlFSoR96AJkxGpKz13g==}
     engines: {node: '>=18'}
     hasBin: true
+
+  motion-dom@12.19.0:
+    resolution: {integrity: sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==}
+
+  motion-utils@12.19.0:
+    resolution: {integrity: sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==}
+
+  motion@12.19.1:
+    resolution: {integrity: sha512-OhoHWrht+zwDPccr2wGltJdwgz2elFBBt/sLei2g0hwICvy2hOBFUkA4Ylup3VnDgz+vUtecf694EV7bJK4XjA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -7153,6 +7190,15 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  framer-motion@12.19.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      motion-dom: 12.19.0
+      motion-utils: 12.19.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   fresh@2.0.0: {}
 
   fsevents@2.3.2:
@@ -7684,6 +7730,20 @@ snapshots:
     dependencies:
       ast-module-types: 6.0.1
       node-source-walk: 7.0.1
+
+  motion-dom@12.19.0:
+    dependencies:
+      motion-utils: 12.19.0
+
+  motion-utils@12.19.0: {}
+
+  motion@12.19.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      framer-motion: 12.19.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
### TL;DR

Enhanced the chat UI with improved message styling, animations, and clipboard functionality.

### What changed?

- Added the `motion` library (v12.19.1) for animations
- Created a reusable `useClipboardCopy` hook to centralize clipboard functionality
- Redesigned message components with improved styling and layout
- Added copy buttons to messages that appear on hover
- Improved animation for reasoning collapsible sections
- Fixed text styling consistency across different message blocks
- Separated message components into `Message` and `StreamingAiMessage` for better organization
- Added visual feedback when copying code or text

### How to test?

1. Start a chat conversation and observe the new message styling
2. Hover over messages to see the copy button appear
3. Click the copy button to copy message content and observe the success indicator
4. Test code blocks to ensure the copy functionality works correctly
5. Expand/collapse reasoning sections to see the new animation effects

### Why make this change?

This change improves the user experience by making the chat interface more polished and interactive. The addition of animations makes interactions feel more responsive, while the centralized clipboard functionality ensures consistent behavior across the application. The redesigned message components provide better visual hierarchy and make it easier for users to interact with chat content.