### PR TITLE
feat(web): fix sizing

### DIFF
--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -96,7 +96,7 @@ const ChatInput = memo(function ChatInput({
 
   return (
     <div className="sticky bottom-0 z-10 bg-background pb-4">
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-2 px-4">
+      <div className="mx-auto flex w-full max-w-full sm:max-w-2xl lg:max-w-4xl flex-col gap-2 px-4">
         <PromptInput
           value={input}
           onValueChange={(val) => {

--- a/apps/web/src/components/chat/message.tsx
+++ b/apps/web/src/components/chat/message.tsx
@@ -52,7 +52,10 @@ function formatDate(date: Date): string {
   return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()} at ${time}`;
 }
 
-const ReasoningCollapsible = memo(function ReasoningCollapsible({ reasoning, status }: ReasoningCollapsibleProps) {
+const ReasoningCollapsible = memo(function ReasoningCollapsible({
+  reasoning,
+  status,
+}: ReasoningCollapsibleProps) {
   if (!reasoning) return null;
   const [reasoningOpen, setReasoningOpen] = useState(false);
   const reasoningHidden = reasoning.text.length === 0;
@@ -60,7 +63,12 @@ const ReasoningCollapsible = memo(function ReasoningCollapsible({ reasoning, sta
   const reasoningTitle = `Thought ${reasoning.duration ? `for ${formatSeconds(reasoning.duration)} seconds` : ""}`;
 
   return (
-    <Collapsible open={reasoningOpen} onOpenChange={setReasoningOpen} hidden={reasoningHidden} className="space-y-2">
+    <Collapsible
+      open={reasoningOpen}
+      onOpenChange={setReasoningOpen}
+      hidden={reasoningHidden}
+      className="space-y-2"
+    >
       <CollapsibleTrigger>
         {!isReasoning ? (
           <div className="flex cursor-pointer items-center gap-x-0.5 text-gray-500">
@@ -70,7 +78,10 @@ const ReasoningCollapsible = memo(function ReasoningCollapsible({ reasoning, sta
               transition={{ duration: 0.2 }}
               style={{ display: "inline-flex" }}
             >
-              <Icon icon="lucide:chevron-right" className="h-4 w-4 bg-transparent text-gray-500" />
+              <Icon
+                icon="lucide:chevron-right"
+                className="h-4 w-4 bg-transparent text-gray-500"
+              />
             </motion.span>
           </div>
         ) : (
@@ -101,7 +112,10 @@ const ReasoningCollapsible = memo(function ReasoningCollapsible({ reasoning, sta
         {!isReasoning && (
           <div className="flex items-center gap-x-2 text-gray-500">
             <div className="flex w-4 shrink-0 justify-center">
-              <Icon icon="lucide:circle-check" className="h-4 w-4 bg-transparent text-gray-500" />
+              <Icon
+                icon="lucide:circle-check"
+                className="h-4 w-4 bg-transparent text-gray-500"
+              />
             </div>
             <span className="text-gray-500">Done</span>
           </div>
@@ -118,7 +132,10 @@ interface MessageProps {
 
 const Message = memo(function Message({ data, user }: MessageProps) {
   const { isCopied, copy } = useClipboardCopy();
-  const contentTokens = useMemo(() => marked.lexer(data.content), [data.content]);
+  const contentTokens = useMemo(
+    () => marked.lexer(data.content),
+    [data.content]
+  );
 
   const isUser = data.role === "user";
   const isAssistant = data.role === "assistant";
@@ -128,27 +145,33 @@ const Message = memo(function Message({ data, user }: MessageProps) {
 
   return (
     <div className="w-full flex flex-col gap-y-2 group">
-      <div className={cn(
-        "py-2 space-y-2",
-        isUser && "px-3 rounded-lg border border-border bg-sidebar-accent text-sidebar-accent-foreground",
-        isAssistant && "px-3 text-foreground",
-        error && "border-red-500",
-      )}>
-        {isAssistant && <ReasoningCollapsible reasoning={data.reasoning} status={data.status} />}
+      <div
+        className={cn(
+          "py-2 space-y-2",
+          isUser &&
+            "px-3 rounded-lg border border-border bg-sidebar-accent text-sidebar-accent-foreground",
+          isAssistant && "text-foreground",
+          error && "border-red-500"
+        )}
+      >
+        {isAssistant && (
+          <ReasoningCollapsible
+            reasoning={data.reasoning}
+            status={data.status}
+          />
+        )}
         <div className="flex gap-x-3">
-          {isUser && <ProfileAvatar image={user?.image ?? ""} name={user?.name ?? ""} className="size-6" />}
+          {isUser && (
+            <ProfileAvatar
+              image={user?.image ?? ""}
+              name={user?.name ?? ""}
+              className="size-6"
+            />
+          )}
           <div className="flex flex-col gap-y-0.5">
-            <div className="flex items-center gap-x-1.5"> 
-              {isUser && (
-                <div className="text-xs text-gray-500">
-                  {name}
-                </div>
-              )}
-              {isUser && (
-                <div className="text-xs text-gray-500">
-                {date}
-              </div>
-              )}
+            <div className="flex items-center gap-x-1.5">
+              {isUser && <div className="text-xs text-gray-500">{name}</div>}
+              {isUser && <div className="text-xs text-gray-500">{date}</div>}
             </div>
             <div className="whitespace-pre-wrap break-words">
               {contentTokens.map((token) => (
@@ -156,7 +179,6 @@ const Message = memo(function Message({ data, user }: MessageProps) {
               ))}
             </div>
           </div>
-          
         </div>
       </div>
       <div className="flex items-center justify-between gap-x-2 min-h-[1.25rem] pl-3">
@@ -185,17 +207,20 @@ const Message = memo(function Message({ data, user }: MessageProps) {
 interface StreamingAiMessageProps {
   readonly data: StreamingMessage;
 }
-const StreamingAiMessage = memo(function StreamingAiMessage({ data }: StreamingAiMessageProps) {
+const StreamingAiMessage = memo(function StreamingAiMessage({
+  data,
+}: StreamingAiMessageProps) {
   const { isCopied, copy } = useClipboardCopy();
-  const contentTokens = useMemo(() => marked.lexer(data.content), [data.content]);
+  const contentTokens = useMemo(
+    () => marked.lexer(data.content),
+    [data.content]
+  );
 
   const error = "error" in data && data.error ? data.error : null;
 
   return (
     <div className="w-full flex flex-col gap-y-2 group">
-      <div className={cn(
-        "px-3 py-2 space-y-2 text-foreground",
-      )}>
+      <div className={cn("px-3 py-2 space-y-2 text-foreground")}>
         <ReasoningCollapsible reasoning={data.reasoning} status={data.status} />
         <div className="flex items-center gap-x-2">
           <div className="whitespace-pre-wrap break-words">

--- a/apps/web/src/components/chat/model-selector.tsx
+++ b/apps/web/src/components/chat/model-selector.tsx
@@ -19,7 +19,7 @@ const ModelSelector = memo(function ModelSelector() {
     (value: string) => {
       setSelectedModelId(Number.parseInt(value));
     },
-    [setSelectedModelId],
+    [setSelectedModelId]
   );
 
   return (
@@ -27,7 +27,7 @@ const ModelSelector = memo(function ModelSelector() {
       value={selectedModelId.toString()}
       onValueChange={handleModelChange}
     >
-      <SelectTrigger className="w-[200px]">
+      <SelectTrigger className="w-fit">
         <SelectValue placeholder="Select model" />
       </SelectTrigger>
       <SelectContent>

--- a/apps/web/src/components/chat/reasoning-effort-selector.tsx
+++ b/apps/web/src/components/chat/reasoning-effort-selector.tsx
@@ -54,7 +54,7 @@ const ReasoningEffortSelector = memo(function ReasoningEffortSelector() {
     <Tooltip>
       <TooltipTrigger asChild>
         <Select value={selectedEffort} onValueChange={handleEffortChange}>
-          <SelectTrigger className="w-[120px]">
+          <SelectTrigger className="w-fit">
             <SelectValue placeholder="Effort" />
           </SelectTrigger>
           <SelectContent>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -76,7 +76,7 @@ function RootDocument({ children }: { readonly children: React.ReactNode }) {
           </SidebarProvider>
         </ThemeProvider>
         <Scripts />
-        <ReactQueryDevtools initialIsOpen={false} />
+        {/* <ReactQueryDevtools initialIsOpen={false} /> */}
         {/* <TanStackRouterDevtools initialIsOpen={false} /> */}
       </body>
     </html>


### PR DESCRIPTION
### TL;DR

Improved UI responsiveness and layout for the chat interface.

### What changed?

- Made the chat input container responsive with different max-widths for various screen sizes
- Improved formatting and spacing in the message component
- Removed padding from assistant messages while preserving it for user messages
- Made model and reasoning effort selectors width adapt to content with `w-fit`
- Commented out ReactQueryDevtools to clean up the UI
- Fixed code formatting and line breaks for better readability

### How to test?

1. Open the chat interface on different screen sizes (mobile, tablet, desktop)
2. Verify that the chat input container adjusts appropriately
3. Check that the model and reasoning effort selectors size correctly based on their content
4. Confirm that user messages have padding while assistant messages don't
5. Ensure the UI looks clean without ReactQueryDevtools

### Why make this change?

These changes improve the responsiveness and visual consistency of the chat interface across different devices. The adjustments to container widths and padding create a better user experience, while the adaptive width for selectors prevents unnecessary empty space. Commenting out the dev tools keeps the production interface clean.