### PR TITLE
feat(web): add auto scroll

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { ChatInput } from "~/components/chat/chat-input";
 import { Message, StreamingAiMessage } from "~/components/chat/message";
 import { useChat } from "~/hooks/use-chat";
@@ -24,6 +24,7 @@ export function ChatView() {
     setSelectedModelId,
   } = useChat(chatId);
   const generateChatTitle = useMutation(api.functions.chat.generateChatTitle);
+  const bottomRef = useRef<HTMLDivElement>(null);
 
   // Restore model sync hook
   useEffect(() => {
@@ -67,6 +68,11 @@ export function ChatView() {
         m.status === "finished"
     );
 
+  useEffect(() => {
+    if (messages.length === 0 && !streamingMessage) return;
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length, streamingMessage]);
+
   return (
     <div className="flex h-full flex-col bg-background">
       <div className="mb-16 flex-1 p-4 mt-5">
@@ -92,6 +98,7 @@ export function ChatView() {
           {showOptimisticMessage && (
             <StreamingAiMessage data={streamingMessage} />
           )}
+          <div ref={bottomRef} />
         </div>
       </div>
       <ChatInput


### PR DESCRIPTION
### TL;DR

Added auto-scrolling functionality to the chat view when new messages appear.

### What changed?

- Added a `useRef` hook to create a reference to a new div element at the bottom of the chat
- Implemented a `useEffect` hook that automatically scrolls to the bottom div whenever new messages are added or when streaming a message
- Added the reference div at the bottom of the message list

### How to test?

1. Open a chat conversation
2. Send multiple messages in succession
3. Verify that the view automatically scrolls to show the newest messages
4. Check that the scrolling behavior is smooth and works correctly when AI responses are streaming in

### Why make this change?

This improves the user experience by ensuring that new messages are always visible without requiring manual scrolling. Users can now see the latest messages as they appear, which is especially important during active conversations or when receiving long AI responses.