### PR TITLE
feat(web): add animation to chat messages

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -1,6 +1,7 @@
 import { useParams } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import { useEffect, useRef } from "react";
+import { AnimatePresence } from "motion/react";
 import { ChatInput } from "~/components/chat/chat-input";
 import { Message, StreamingAiMessage } from "~/components/chat/message";
 import { useChat } from "~/hooks/use-chat";
@@ -82,18 +83,20 @@ export function ChatView() {
               <h1 className="text-2xl">Where should we begin?</h1>
             </div>
           ) : (
-            messages.map((m, index) => {
-              if (
-                (m.role === "assistant" &&
-                  status === "streaming" &&
-                  index === messages.length - 1) ||
-                m.status === "generating" ||
-                m.status === "reasoning"
-              ) {
-                return null;
-              }
-              return <Message key={m._id} data={m} user={session?.user} />;
-            })
+            <AnimatePresence initial={false}>
+              {messages.map((m, index) => {
+                if (
+                  (m.role === "assistant" &&
+                    status === "streaming" &&
+                    index === messages.length - 1) ||
+                  m.status === "generating" ||
+                  m.status === "reasoning"
+                ) {
+                  return null;
+                }
+                return <Message key={m._id} data={m} user={session?.user} />;
+              })}
+            </AnimatePresence>
           )}
           {showOptimisticMessage && (
             <StreamingAiMessage data={streamingMessage} />

--- a/apps/web/src/components/chat/message.tsx
+++ b/apps/web/src/components/chat/message.tsx
@@ -144,7 +144,16 @@ const Message = memo(function Message({ data, user }: MessageProps) {
   const error = "error" in data && data.error ? data.error : null;
 
   return (
-    <div className="max-w-full flex flex-col gap-y-2 group">
+    <motion.div
+      className="max-w-full flex flex-col gap-y-2 group"
+      {...(isUser
+        ? {
+            initial: { opacity: 0, y: 20 },
+            animate: { opacity: 1, y: 0 },
+            transition: { duration: 0.25 },
+          }
+        : {})}
+    >
       <div
         className={cn(
           "py-2 space-y-2",
@@ -200,7 +209,7 @@ const Message = memo(function Message({ data, user }: MessageProps) {
           </Button>
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 });
 


### PR DESCRIPTION
### TL;DR

Added animation to user messages in the chat interface.

### What changed?

- Imported `AnimatePresence` from `motion/react`
- Wrapped the message list in `<AnimatePresence>` to manage animations when messages are added or removed
- Converted the message container from a `div` to a `motion.div` to enable animations
- Added animation properties (opacity and y-position) specifically for user messages
- Set animation transition duration to 0.25 seconds

### How to test?

1. Open the chat interface
2. Send a new message as a user
3. Verify that the message animates in with a fade-up effect
4. Check that only user messages have the animation, not assistant messages

### Why make this change?

This change enhances the user experience by adding subtle animations when new user messages appear in the chat. The fade-in and slide-up effect creates a more dynamic and polished interface, making the conversation feel more responsive and engaging.