### PR TITLE
feat(web): add icons to model selector

### DIFF
--- a/apps/web/src/components/chat/model-selector.tsx
+++ b/apps/web/src/components/chat/model-selector.tsx
@@ -1,65 +1,54 @@
-import { Check, ChevronDown } from "lucide-react";
-import { memo, useCallback, useState } from "react";
-import { Button } from "~/components/ui/button";
+import { memo, useCallback } from "react";
+import { Icon } from "@iconify/react";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "~/components/ui/popover";
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
 import { usePersisted } from "~/hooks/use-persisted";
-import { getDefaultModel, models } from "~/lib/models";
-import { cn } from "~/lib/utils";
+import { getCompanyIcon, getDefaultModel, models } from "~/lib/models";
 
 export const MODEL_PERSIST_KEY = "selected-model";
 
 const ModelSelector = memo(function ModelSelector() {
-  const [isOpen, setIsOpen] = useState(false);
   const { value: selectedModelId, set: setSelectedModelId } =
     usePersisted<number>(MODEL_PERSIST_KEY, getDefaultModel().id);
 
-  const selectedModel =
-    models.find((m) => m.id === selectedModelId) || getDefaultModel();
-
-  const handleModelSelect = useCallback(
-    (modelId: number) => {
-      setSelectedModelId(modelId);
-      setIsOpen(false);
+  const handleModelChange = useCallback(
+    (value: string) => {
+      setSelectedModelId(Number.parseInt(value));
     },
-    [setSelectedModelId],
+    [setSelectedModelId]
   );
 
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-8 justify-between gap-1 px-2 text-muted-foreground text-xs hover:text-foreground"
-        >
-          <span>{selectedModel.name}</span>
-          <ChevronDown className="h-3 w-3" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-56 p-1">
-        <div className="flex flex-col gap-0.5">
-          {models.map((model) => (
-            <Button
-              key={model.id}
-              variant="ghost"
-              size="sm"
-              className={cn(
-                "h-8 justify-between px-2 text-xs hover:bg-accent hover:text-accent-foreground",
-                selectedModelId === model.id && "bg-accent",
+    <Select
+      value={selectedModelId.toString()}
+      onValueChange={handleModelChange}
+    >
+      <SelectTrigger className="w-fit bg-transparent dark:bg-transparent border-none shadow-none">
+        <SelectValue placeholder="Select model" />
+      </SelectTrigger>
+      <SelectContent>
+        {models.map((model) => {
+          const iconName = getCompanyIcon(model);
+          return (
+            <SelectItem key={model.id} value={model.id.toString()}>
+              {iconName ? (
+                <span className="flex items-center gap-2">
+                  <Icon icon={iconName} className="size-4 bg-transparent" />
+                  {model.name}
+                </span>
+              ) : (
+                model.name
               )}
-              onClick={() => handleModelSelect(model.id)}
-            >
-              <span>{model.name}</span>
-              {selectedModelId === model.id && <Check className="h-3 w-3" />}
-            </Button>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
   );
 });
 

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -17,6 +17,36 @@ export const ReasoningEffort = {
 export type EffortKey = keyof typeof ReasoningEffort;
 export type EffortLabel = (typeof ReasoningEffort)[EffortKey];
 
+export const COMPANY_ICONS = {
+  anthropic: "simple-icons:anthropic",
+  openai: "simple-icons:openai",
+  gemini: "simple-icons:googlegemini",
+} as const;
+
+export type CompanyKey = keyof typeof COMPANY_ICONS;
+
+const COMPANY_PATTERNS: Record<CompanyKey, readonly RegExp[]> = {
+  anthropic: [/claude/i, /anthropic/i],
+  openai: [/gpt/i, /openai/i, /^o4/i],
+  gemini: [/gemini/i],
+};
+
+export const getCompanyKey = (
+  modelOrName: Model | string
+): CompanyKey | undefined => {
+  const name = typeof modelOrName === "string" ? modelOrName : modelOrName.name;
+  return (Object.keys(COMPANY_PATTERNS) as CompanyKey[]).find((key) =>
+    COMPANY_PATTERNS[key].some((pattern) => pattern.test(name))
+  );
+};
+
+export const getCompanyIcon = (
+  modelOrName: Model | string
+): string | undefined => {
+  const key = getCompanyKey(modelOrName);
+  return key ? COMPANY_ICONS[key] : undefined;
+};
+
 export const getSystemPrompt = (model: Model, userName: string) => {
   const modelName = model.name;
 


### PR DESCRIPTION
### TL;DR

Added company icons to the model selector dropdown to visually distinguish between different AI providers.

### What changed?

- Added the `@iconify/react` package to display company icons
- Created utility functions in `models.ts` to identify AI providers based on model names:
  - `getCompanyKey`: Identifies the company (Anthropic, OpenAI, Gemini) based on model name patterns
  - `getCompanyIcon`: Returns the appropriate icon name for a given model
- Enhanced the model selector UI to display company icons next to model names in the dropdown

### How to test?

1. Open the chat interface
2. Click on the model selector dropdown
3. Verify that models from different providers (OpenAI, Anthropic, Gemini) display their respective company icons
4. Confirm that models with unrecognized patterns still display correctly without icons

### Why make this change?

This visual enhancement makes it easier for users to quickly identify which company provides each AI model in the dropdown. The icons serve as visual cues that improve the user experience by making the model selection more intuitive, especially for users who may recognize company logos more readily than model names.