### PR TITLE
feat(web): enhance model selector with recently updated indicator

### DIFF
--- a/apps/web/src/components/chat/model-selector.tsx
+++ b/apps/web/src/components/chat/model-selector.tsx
@@ -9,6 +9,13 @@ import {
 } from "~/components/ui/select";
 import { usePersisted } from "~/hooks/use-persisted";
 import { getCompanyIcon, getDefaultModel, models } from "~/lib/models";
+import { AnimatedShinyText } from "~/components/ui/animated-shiny-text";
+import { Sparkles } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "~/components/ui/tooltip";
 
 export const MODEL_PERSIST_KEY = "selected-model";
 
@@ -34,16 +41,41 @@ const ModelSelector = memo(function ModelSelector() {
       <SelectContent>
         {models.map((model) => {
           const iconName = getCompanyIcon(model);
+          const nameElement = model.recentlyUpdated ? (
+            <AnimatedShinyText shimmerWidth={100}>
+              {model.name}
+            </AnimatedShinyText>
+          ) : (
+            model.name
+          );
+
+          const updatedSparkles = model.recentlyUpdated ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="pointer-events-auto">
+                  <Sparkles className="size-3 text-orange-400" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="right">Recently updated</TooltipContent>
+            </Tooltip>
+          ) : null;
+
+          const content = iconName ? (
+            <span className="flex items-center gap-2">
+              <Icon icon={iconName} className="size-4 bg-transparent" />
+              {nameElement}
+              {updatedSparkles}
+            </span>
+          ) : (
+            <span className="flex items-center gap-2">
+              {nameElement}
+              {updatedSparkles}
+            </span>
+          );
+
           return (
             <SelectItem key={model.id} value={model.id.toString()}>
-              {iconName ? (
-                <span className="flex items-center gap-2">
-                  <Icon icon={iconName} className="size-4 bg-transparent" />
-                  {model.name}
-                </span>
-              ) : (
-                model.name
-              )}
+              {content}
             </SelectItem>
           );
         })}

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -6,6 +6,7 @@ export interface Model {
   readonly premium: boolean;
   readonly reasoningEffort: boolean;
   readonly isDefault?: boolean;
+  readonly recentlyUpdated?: boolean;
 }
 
 export const ReasoningEffort = {
@@ -126,6 +127,7 @@ export const models: readonly Model[] = [
     premium: false,
     reasoningEffort: false,
     isDefault: false,
+    recentlyUpdated: true,
   },
   {
     id: 4,
@@ -138,10 +140,11 @@ export const models: readonly Model[] = [
   {
     id: 5,
     name: "Gemini 2.5 Pro",
-    modelId: "google/gemini-2.5-pro-preview",
+    modelId: "google/gemini-2.5-pro",
     provider: "openrouter",
     premium: false,
     reasoningEffort: true,
+    recentlyUpdated: true,
   },
   {
     id: 6,


### PR DESCRIPTION
### TL;DR

Added visual indicators for recently updated models in the model selector dropdown.

### What changed?

- Added a `recentlyUpdated` flag to the `Model` interface
- Marked Claude 3.5 Sonnet and Gemini 2.5 Pro as recently updated models
- Updated Gemini 2.5 Pro's model ID from `google/gemini-2.5-pro-preview` to `google/gemini-2.5-pro`
- Added visual indicators for recently updated models:
  - Shimmering text effect using `AnimatedShinyText` component
  - A sparkles icon with a tooltip that says "Recently updated"

### How to test?

1. Open the model selector dropdown in the chat interface
2. Verify that Claude 3.5 Sonnet and Gemini 2.5 Pro have:
   - Shimmering text effect on their names
   - A small orange sparkles icon next to their names
   - A tooltip that appears when hovering over the sparkles icon

### Why make this change?

This change helps users quickly identify which models have been recently updated, drawing attention to new or improved capabilities. The visual indicators make it easier for users to discover and try the latest model versions.