### PR TITLE
feat(web): add premium model indicator

### DIFF
--- a/apps/web/src/components/chat/model-selector.tsx
+++ b/apps/web/src/components/chat/model-selector.tsx
@@ -10,7 +10,7 @@ import {
 import { usePersisted } from "~/hooks/use-persisted";
 import { getCompanyIcon, getDefaultModel, models } from "~/lib/models";
 import { AnimatedShinyText } from "~/components/ui/animated-shiny-text";
-import { Sparkles } from "lucide-react";
+import { Sparkles, Gem } from "lucide-react";
 import {
   Tooltip,
   TooltipTrigger,
@@ -49,6 +49,17 @@ const ModelSelector = memo(function ModelSelector() {
             model.name
           );
 
+          const premiumGem = model.premium ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="pointer-events-auto">
+                  <Gem className="size-3 text-sky-400" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="right">Premium model</TooltipContent>
+            </Tooltip>
+          ) : null;
+
           const updatedSparkles = model.recentlyUpdated ? (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -64,11 +75,13 @@ const ModelSelector = memo(function ModelSelector() {
             <span className="flex items-center gap-2">
               <Icon icon={iconName} className="size-4 bg-transparent" />
               {nameElement}
+              {premiumGem}
               {updatedSparkles}
             </span>
           ) : (
             <span className="flex items-center gap-2">
               {nameElement}
+              {premiumGem}
               {updatedSparkles}
             </span>
           );


### PR DESCRIPTION
### TL;DR

Added a premium model indicator with a gem icon in the model selector.

### What changed?

- Imported the `Gem` icon from lucide-react
- Added a premium gem indicator that displays for models marked as premium
- Implemented a tooltip that shows "Premium model" when hovering over the gem icon
- Integrated the premium gem indicator into the model display in both icon and non-icon views

### How to test?

1. Open the chat interface
2. Click on the model selector dropdown
3. Verify that models marked as premium display a blue gem icon
4. Hover over the gem icon to confirm the "Premium model" tooltip appears

### Why make this change?

To provide users with clear visual indication of which models are premium, helping them make informed decisions when selecting a model for their conversation.