### PR TITLE
feat(web): update models

### DIFF
--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -132,10 +132,11 @@ export const models: readonly Model[] = [
   {
     id: 4,
     name: "Gemini 2.5 Flash",
-    modelId: "google/gemini-2.5-flash-preview-05-20",
+    modelId: "google/gemini-2.5-flash",
     provider: "openrouter",
     premium: false,
     reasoningEffort: false,
+    recentlyUpdated: true,
   },
   {
     id: 5,


### PR DESCRIPTION
### TL;DR

Updated the Gemini 2.5 Flash model configuration from preview to stable release.

### What changed?

- Changed the `modelId` from `google/gemini-2.5-flash-preview-05-20` to `google/gemini-2.5-flash`
- Added the `recentlyUpdated: true` flag to the model configuration

### How to test?

1. Verify that the Gemini 2.5 Flash model is accessible in the application
2. Confirm that the model appears with a "Recently Updated" indicator (if applicable in the UI)
3. Test that conversations with this model work correctly using the new stable model ID

### Why make this change?

Google has released the stable version of Gemini 2.5 Flash, so we're updating our configuration to use the official release instead of the preview version. Adding the `recentlyUpdated` flag will help users identify that this model has been recently updated.