### PR TITLE
fix(web): theme flicker bug

### DIFF
--- a/apps/web/src/components/chat/model-selector.tsx
+++ b/apps/web/src/components/chat/model-selector.tsx
@@ -1,5 +1,7 @@
-import { memo, useState } from "react";
 import { Icon } from "@iconify/react";
+import { Check, ChevronDown, Gem, Sparkles } from "lucide-react";
+import { memo, useState } from "react";
+import { AnimatedShinyText } from "~/components/ui/animated-shiny-text";
 import { Button } from "~/components/ui/button";
 import {
   Command,
@@ -14,15 +16,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "~/components/ui/popover";
-import { usePersisted } from "~/hooks/use-persisted";
-import { getCompanyIcon, getDefaultModel, models } from "~/lib/models";
-import { AnimatedShinyText } from "~/components/ui/animated-shiny-text";
-import { Sparkles, Gem, ChevronDown, Check } from "lucide-react";
 import {
   Tooltip,
-  TooltipTrigger,
   TooltipContent,
+  TooltipTrigger,
 } from "~/components/ui/tooltip";
+import { usePersisted } from "~/hooks/use-persisted";
+import { getCompanyIcon, getDefaultModel, models } from "~/lib/models";
 import { cn } from "~/lib/utils";
 
 export const MODEL_PERSIST_KEY = "selected-model";
@@ -88,7 +88,7 @@ const ModelSelector = memo(function ModelSelector() {
         <Button
           variant="ghost"
           size="sm"
-          className="h-8 justify-between gap-1 px-2 text-muted-foreground text-xs hover:text-foreground w-fit bg-transparent dark:bg-transparent border-none shadow-none"
+          className="h-8 w-fit justify-between gap-1 border-none bg-transparent px-2 text-muted-foreground text-xs shadow-none hover:text-foreground dark:bg-transparent"
         >
           {selectedModel ? renderModelContent(selectedModel) : "Select model"}
           <ChevronDown className="ml-2 h-3 w-3" />
@@ -123,7 +123,9 @@ const ModelSelector = memo(function ModelSelector() {
                   <Check
                     className={cn(
                       "ml-auto size-4",
-                      selectedModelId === model.id ? "opacity-100" : "opacity-0"
+                      selectedModelId === model.id
+                        ? "opacity-100"
+                        : "opacity-0",
                     )}
                   />
                 </CommandItem>

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import type * as React from "react";
 import { Command as CommandPrimitive } from "cmdk";
 import { SearchIcon } from "lucide-react";
+import type * as React from "react";
 
-import { cn } from "~/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -12,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "~/components/ui/dialog";
+import { cn } from "~/lib/utils";
 
 function Command({
   className,
@@ -21,8 +21,8 @@ function Command({
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
-        className
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className,
       )}
       {...props}
     />
@@ -52,7 +52,7 @@ function CommandDialog({
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>
@@ -73,8 +73,8 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-          className
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className,
         )}
         {...props}
       />
@@ -90,8 +90,8 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
-        className
+        "max-h-[300px] scroll-py-1 overflow-y-auto overflow-x-hidden",
+        className,
       )}
       {...props}
     />
@@ -118,8 +118,8 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
-        className
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:text-xs",
+        className,
       )}
       {...props}
     />
@@ -133,7 +133,7 @@ function CommandSeparator({
   return (
     <CommandPrimitive.Separator
       data-slot="command-separator"
-      className={cn("bg-border -mx-1 h-px", className)}
+      className={cn("-mx-1 h-px bg-border", className)}
       {...props}
     />
   );
@@ -147,8 +147,8 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
       )}
       {...props}
     />
@@ -163,8 +163,8 @@ function CommandShortcut({
     <span
       data-slot="command-shortcut"
       className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
+        "ml-auto text-muted-foreground text-xs tracking-widest",
+        className,
       )}
       {...props}
     />

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -34,7 +34,7 @@ const COMPANY_PATTERNS: Record<CompanyKey, readonly RegExp[]> = {
 };
 
 export const getCompanyKey = (
-  modelOrName: Model | string
+  modelOrName: Model | string,
 ): CompanyKey | undefined => {
   if (typeof modelOrName !== "string") {
     return modelOrName.company;
@@ -42,12 +42,12 @@ export const getCompanyKey = (
 
   const name = modelOrName;
   return (Object.keys(COMPANY_PATTERNS) as CompanyKey[]).find((key) =>
-    COMPANY_PATTERNS[key].some((pattern) => pattern.test(name))
+    COMPANY_PATTERNS[key].some((pattern) => pattern.test(name)),
   );
 };
 
 export const getCompanyIcon = (
-  modelOrName: Model | string
+  modelOrName: Model | string,
 ): string | undefined => {
   const key = getCompanyKey(modelOrName);
   return key ? COMPANY_ICONS[key] : undefined;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -40,7 +40,11 @@ export const Route = createRootRouteWithContext<{
       },
     ],
     links: [{ rel: "stylesheet", href: appCss }],
-    scripts: [],
+    scripts: [
+      {
+        children: `!function(){try{var t=localStorage.getItem("local:theme");if(t){var e=JSON.parse(t);if(e?.state?.value){var a=e.state.value;"dark"===a?document.documentElement.classList.add("dark"):"light"===a?document.documentElement.classList.add("light"):"system"===a&&window.matchMedia("(prefers-color-scheme: dark)").matches&&document.documentElement.classList.add("dark")}}}catch(t){}}();`,
+      },
+    ],
   }),
   component: RootComponent,
 });


### PR DESCRIPTION
### TL;DR

Added dark mode support with a script that applies theme classes on initial page load to prevent flash of incorrect theme.

### What changed?

- Added an inline script in `__root.tsx` that reads the theme preference from localStorage and applies the appropriate class (`dark` or `light`) to the document element before the page renders
- Reorganized imports in several files for better code organization
- Fixed CSS class ordering in `command.tsx` and `model-selector.tsx` to follow a consistent pattern
- Improved conditional rendering of the check icon in the model selector with better formatting

### How to test?

1. Set your theme preference to dark mode in the application
2. Refresh the page and verify there's no flash of light theme before the dark theme is applied
3. Test the same with light mode and system preference settings

### Why make this change?

This change prevents the flash of incorrect theme that occurs when the page initially loads with the default theme before the application code runs and applies the user's preferred theme. By adding an inline script that executes immediately, the correct theme class is applied before any content is rendered to the user.