### PR TITLE
feat(web): add attachments tooltip

### DIFF
--- a/apps/web/src/components/chat/file-attachment-button.tsx
+++ b/apps/web/src/components/chat/file-attachment-button.tsx
@@ -8,6 +8,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "~/components/ui/popover";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "~/components/ui/tooltip";
 import { cn } from "~/lib/utils";
 
 interface FileAttachmentButtonProps {
@@ -52,7 +57,6 @@ export function FileAttachmentButton({
     }
   };
 
-
   const openFileDialog = () => {
     fileInputRef.current?.click();
   };
@@ -72,26 +76,33 @@ export function FileAttachmentButton({
       />
 
       <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className={cn(
-              "relative h-8 w-8 p-0 text-muted-foreground hover:text-foreground",
-              hasAttachments && "text-primary hover:text-primary",
-              className,
-            )}
-            disabled={disabled}
-          >
-            <motion.div
-              animate={{ rotate: isOpen ? 45 : 0 }}
-              transition={{ duration: 0.2, ease: "easeInOut" }}
-              className="absolute inset-0 flex items-center justify-center"
-            >
-              <Plus className="h-4 w-4" />
-            </motion.div>
-          </Button>
-        </PopoverTrigger>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "relative h-8 w-8 p-0 text-muted-foreground hover:text-foreground",
+                  hasAttachments && "text-primary hover:text-primary",
+                  className
+                )}
+                disabled={disabled}
+              >
+                <motion.div
+                  animate={{ rotate: isOpen ? 45 : 0 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                  className="absolute inset-0 flex items-center justify-center"
+                >
+                  <Plus className="h-4 w-4" />
+                </motion.div>
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Add photos or files</p>
+          </TooltipContent>
+        </Tooltip>
         <PopoverContent className="w-80 p-2" align="start" side="top">
           <div className="space-y-3">
             <Button


### PR DESCRIPTION
### TL;DR

Added a tooltip to the file attachment button that displays "Add photos or files" when hovering.

### What changed?

- Imported Tooltip components from the UI library
- Wrapped the existing PopoverTrigger with a Tooltip component
- Added TooltipContent with the text "Add photos or files"
- Maintained all existing functionality of the file attachment button

### How to test?

1. Navigate to any chat interface
2. Hover over the file attachment button (the plus icon)
3. Verify that a tooltip appears with the text "Add photos or files"
4. Ensure the button still functions correctly when clicked (opens the file attachment popover)

### Why make this change?

This change improves the user experience by providing clear guidance on the button's purpose. The tooltip helps users understand that the plus icon is for attaching files and photos without needing to click it first, making the interface more intuitive and accessible.