### PR TITLE
fix(web): fix reasoning effort tooltip

### DIFF
--- a/apps/web/src/components/chat/reasoning-effort-selector.tsx
+++ b/apps/web/src/components/chat/reasoning-effort-selector.tsx
@@ -33,12 +33,12 @@ const ReasoningEffortSelector = memo(function ReasoningEffortSelector() {
   const [isOpen, setIsOpen] = useState(false);
   const { value: selectedModelId } = usePersisted<number>(
     MODEL_PERSIST_KEY,
-    getDefaultModel().id,
+    getDefaultModel().id
   );
   const { value: selectedEffort, set: setSelectedEffort } =
     usePersisted<EffortLabel>(
       REASONING_EFFORT_PERSIST_KEY,
-      ReasoningEffort.LOW,
+      ReasoningEffort.LOW
     );
 
   const selectedModel = getModelById(selectedModelId);
@@ -48,16 +48,16 @@ const ReasoningEffortSelector = memo(function ReasoningEffortSelector() {
       setSelectedEffort(effort);
       setIsOpen(false);
     },
-    [setSelectedEffort],
+    [setSelectedEffort]
   );
 
   if (!selectedModel || !selectedModel.reasoningEffort) return null;
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Popover open={isOpen} onOpenChange={setIsOpen}>
-          <PopoverTrigger asChild>
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>
+          <TooltipTrigger asChild>
             <Button
               variant="ghost"
               size="sm"
@@ -69,30 +69,28 @@ const ReasoningEffortSelector = memo(function ReasoningEffortSelector() {
               </span>
               <ChevronDown className="h-3 w-3" />
             </Button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-40 p-1">
-            <div className="flex flex-col gap-0.5">
-              {effortOptions.map((effort) => (
-                <Button
-                  key={effort}
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "h-8 justify-between px-2 text-xs hover:bg-accent hover:text-accent-foreground",
-                    selectedEffort === effort && "bg-accent",
-                  )}
-                  onClick={() => handleEffortSelect(effort)}
-                >
-                  <span>
-                    {effort.charAt(0).toUpperCase() + effort.slice(1)}
-                  </span>
-                  {selectedEffort === effort && <Check className="h-3 w-3" />}
-                </Button>
-              ))}
-            </div>
-          </PopoverContent>
-        </Popover>
-      </TooltipTrigger>
+          </TooltipTrigger>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-40 p-1">
+          <div className="flex flex-col gap-0.5">
+            {effortOptions.map((effort) => (
+              <Button
+                key={effort}
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "h-8 justify-between px-2 text-xs hover:bg-accent hover:text-accent-foreground",
+                  selectedEffort === effort && "bg-accent"
+                )}
+                onClick={() => handleEffortSelect(effort)}
+              >
+                <span>{effort.charAt(0).toUpperCase() + effort.slice(1)}</span>
+                {selectedEffort === effort && <Check className="h-3 w-3" />}
+              </Button>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
       <TooltipContent>Reasoning effort</TooltipContent>
     </Tooltip>
   );


### PR DESCRIPTION
### TL;DR

Fixed the tooltip and popover nesting in the reasoning effort selector component.

### What changed?

Restructured the component hierarchy in `reasoning-effort-selector.tsx` to properly nest the tooltip and popover components. The previous implementation had the tooltip trigger wrapping the popover, which was causing issues with the UI behavior. Now the popover is at the top level with the tooltip trigger properly nested inside the popover trigger.

Also removed trailing commas from several function calls and array definitions for consistency with the codebase style.

### How to test?

1. Open the chat interface
2. Hover over the reasoning effort selector button to verify the tooltip appears correctly
3. Click the reasoning effort selector to verify the dropdown menu opens properly
4. Select different reasoning effort options to ensure they work as expected

### Why make this change?

The previous component hierarchy was causing issues with the tooltip and popover interaction. This change ensures that both UI elements work correctly together, providing a better user experience when selecting reasoning effort levels.