### PR TITLE
chore(web): update React-scan and reenable

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,7 +53,7 @@
     "motion": "12.19.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-scan": "^0.3.4",
+    "react-scan": "^0.4.3",
     "react-syntax-highlighter": "15.6.1",
     "tailwind-merge": "3.3.0",
     "tw-animate-css": "^1.3.4",

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -60,8 +60,8 @@ function RootComponent() {
 function RootDocument({ children }: { readonly children: React.ReactNode }) {
   useEffect(() => {
     scan({
-      enabled: false,
-      showToolbar: false,
+      enabled: true,
+      showToolbar: true,
     });
   }, []);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
       react-scan:
-        specifier: ^0.3.4
-        version: 0.3.4(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.42.0)
+        specifier: ^0.4.3
+        version: 0.4.3(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.42.0)
       react-syntax-highlighter:
         specifier: 15.6.1
         version: 15.6.1(react@19.1.0)
@@ -3767,8 +3767,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-scan@0.3.4:
-    resolution: {integrity: sha512-jUkgs+sfK1B7T1jvZ0rQmKZtvUUE7cHB6qDTfCfOTmTJYH2aAFB1fGmE4DXBbQ1kUF+AdjyNT0Lc73LL/dQIbg==}
+  react-scan@0.4.3:
+    resolution: {integrity: sha512-jhAQuQ1nja6HUYrSpbmNFHqZPsRCXk8Yqu0lHoRIw9eb8N96uTfXCpVyQhTTnJ/nWqnwuvxbpKVG/oWZT8+iTQ==}
     hasBin: true
     peerDependencies:
       '@remix-run/react': '>=1.0.0'
@@ -8280,7 +8280,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.6
 
-  react-scan@0.3.4(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.42.0):
+  react-scan@0.4.3(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.42.0):
     dependencies:
       '@babel/core': 7.27.4
       '@babel/generator': 7.27.5


### PR DESCRIPTION
### TL;DR

Upgraded react-scan from v0.3.4 to v0.4.3 and enabled its toolbar in the web app.

### What changed?

- Updated the react-scan dependency from version 0.3.4 to 0.4.3 in package.json
- Enabled the react-scan functionality by changing both `enabled` and `showToolbar` flags from `false` to `true` in the RootDocument component

### How to test?

1. Run the web application
2. Verify that the react-scan toolbar is now visible in the UI
3. Confirm that the scanning functionality works as expected with the new version

### Why make this change?

This update enables the react-scan debugging toolbar by default, which provides better development tools for identifying and resolving React-related issues. The version upgrade to 0.4.3 likely includes bug fixes and new features that will improve the development experience.