### PR TITLE
feat(web): add web search capability to chat API

### DIFF
--- a/apps/web/src/lib/ai/webSearch.ts
+++ b/apps/web/src/lib/ai/webSearch.ts
@@ -1,0 +1,50 @@
+import { tool } from "ai";
+import { Effect } from "effect";
+import { pipe } from "effect/Function";
+import { z } from "zod";
+import { exa } from "~/lib/exa";
+
+const DEFAULT_NUM_RESULTS = 3;
+const DEFAULT_LIVECRAWL = "always" as const;
+
+type SearchResult = {
+  title: string;
+  url: string;
+  content: string;
+  publishedDate?: string;
+};
+
+export const webSearch = tool({
+  description: "Search the web for up-to-date information",
+  parameters: z
+    .object({
+      query: z.string().min(1).max(100).describe("The search query"),
+    })
+    .strict(),
+  execute: async ({ query }): Promise<SearchResult[]> => {
+    console.log(`[Chat API][Web Search] searching: ${query}`);
+
+    const searchEffect = Effect.tryPromise({
+      try: () =>
+        exa.searchAndContents(query, {
+          livecrawl: DEFAULT_LIVECRAWL,
+          numResults: DEFAULT_NUM_RESULTS,
+        }),
+      catch: (err) => new Error(String(err)),
+    });
+
+    const transformEffect = pipe(
+      searchEffect,
+      Effect.map(({ results }) =>
+        results.map<SearchResult>((r) => ({
+          title: r.title ?? "",
+          url: r.url ?? "",
+          content: (r.text ?? "").slice(0, 1000),
+          publishedDate: r.publishedDate ?? undefined,
+        }))
+      )
+    );
+
+    return Effect.runPromise(transformEffect);
+  },
+});


### PR DESCRIPTION
### TL;DR

Added web search capability to the chat API using the Exa search engine.

### What changed?

- Created a new `webSearch.ts` file that implements a search tool using the Exa API
- Integrated the web search tool into the chat API route
- Modified the chat API to conditionally use the search tool when the `search` parameter is true
- Added tool support with a maximum of 2 steps for search-enabled conversations
- Removed the `:online` suffix appending to model IDs, using the tools approach instead

### How to test?

1. Make a request to the chat API with `search: true` in the request parameters
2. Verify that the web search tool is activated when search is enabled
3. Check the console logs for "[Chat API][Web Search] searching: {query}" to confirm search execution
4. Confirm that search results are properly integrated into the AI's response

### Why make this change?

This change enhances the chat functionality by providing up-to-date information from the web when needed. Instead of using a model-specific approach with the `:online` suffix, this implementation uses the more flexible tools API, which allows for better control over the search process and integration of search results into the conversation.