### PR TITLE
feat(web): increase maxSteps from 2 to 3 in chat API

### DIFF
--- a/apps/web/src/routes/api/chat.ts
+++ b/apps/web/src/routes/api/chat.ts
@@ -346,7 +346,7 @@ export const ServerRoute = createServerFileRoute("/api/chat").methods({
         abortSignal: request.signal,
         ...(providerOptions ? { providerOptions } : {}),
         tools: tools,
-        maxSteps: 2,
+        maxSteps: 3,
       });
 
       const messageId = await createAiMessage({


### PR DESCRIPTION
### TL;DR

Increased the maximum number of tool execution steps from 2 to 3 in the chat API.

### What changed?

Modified the `maxSteps` parameter in the chat API route from 2 to 3, allowing the AI to execute up to 3 tool operations in sequence when responding to user queries.

### How to test?

1. Make a request to the chat API that requires multiple tool executions
2. Verify that the AI can now perform up to 3 sequential tool operations
3. Test complex queries that previously might have been limited by the 2-step restriction

### Why make this change?

This change allows the AI to handle more complex queries that require additional tool execution steps. The previous limit of 2 steps may have been insufficient for certain scenarios where the AI needs to gather information from multiple sources or perform a series of related operations to provide a complete response.