### PR TITLE
fix(web): first message attachment

### DIFF
--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -68,19 +68,14 @@ const ChatInput = memo(function ChatInput({
   }, []);
 
   const send = useCallback(
-    async (input: string) => {
-      const text = input.trim();
+    async (text: string) => {
       if (!text && attachedFiles.length === 0) return;
 
       if (!chatId) {
         try {
           localStorage.setItem("firstMessage", text || "");
-
           if (attachedFiles.length > 0) {
-            localStorage.setItem(
-              "firstMessageAttachments",
-              JSON.stringify(attachedFiles),
-            );
+            inputStore.getState().setFiles(attachedFiles.map((af) => af.file));
           }
 
           const model = getModelById(selectedModelId);
@@ -155,11 +150,15 @@ const ChatInput = memo(function ChatInput({
   );
 
   const handleSubmit = useCallback(() => {
-    const currentInput = inputStore.getState().input;
+    const currentInput = inputStore.getState().input.trim();
+    if (!currentInput && attachedFiles.length === 0) {
+      return;
+    }
+
     send(currentInput);
     setInput("");
     inputStore.getState().setInput("");
-  }, [send]);
+  }, [send, attachedFiles.length]);
 
   const isDisabled = useCallback(() => {
     return (

--- a/apps/web/src/components/chat/stores.ts
+++ b/apps/web/src/components/chat/stores.ts
@@ -10,18 +10,27 @@ export interface AttachedFile {
   attachmentId?: string;
 }
 
+export interface SerializedAttachedFile {
+  name: string;
+  size: number;
+  type: string;
+  lastModified: number;
+  data: string; // base64 encoded
+  progress?: number;
+  error?: string;
+  attachmentId?: string;
+}
+
 type InputStore = {
   input: string;
   disabled: boolean;
   attachedFiles: AttachedFile[];
   setInput: (input: string) => void;
   setDisabled: (disabled: boolean) => void;
-  addFiles: (files: File[]) => void;
+  setFiles: (files: File[]) => void;
   removeFile: (index: number) => void;
-  updateFileProgress: (index: number, progress: number) => void;
-  updateFileError: (index: number, error: string) => void;
-  updateFileAttachmentId: (index: number, attachmentId: string) => void;
   clearFiles: () => void;
+  getPendingAttachments: () => SerializedAttachedFile[];
 };
 
 export const inputStore = createStore(
@@ -32,38 +41,84 @@ export const inputStore = createStore(
       attachedFiles: [],
       setInput: (input: string) => set({ input }),
       setDisabled: (disabled: boolean) => set({ disabled }),
-      addFiles: (files: File[]) => {
+      setFiles: (files: File[]) => {
         const newFiles: AttachedFile[] = files.map((file) => ({
           file,
           progress: 0,
         }));
-        set((state) => ({
-          attachedFiles: [...state.attachedFiles, ...newFiles],
-        }));
+        set((state) => {
+          // Sync to sessionStorage
+          const serializedFiles = newFiles.map(async (af: AttachedFile) => {
+            const arrayBuffer = await af.file.arrayBuffer();
+            const uint8Array = new Uint8Array(arrayBuffer);
+            const data = btoa(String.fromCharCode(...uint8Array));
+
+            return {
+              name: af.file.name,
+              size: af.file.size,
+              type: af.file.type,
+              lastModified: af.file.lastModified,
+              data,
+              progress: af.progress,
+              error: af.error,
+              attachmentId: af.attachmentId,
+            };
+          });
+
+          Promise.all(serializedFiles).then((files) => {
+            sessionStorage.setItem("pendingAttachments", JSON.stringify(files));
+          });
+
+          return { attachedFiles: newFiles };
+        });
       },
       removeFile: (index: number) =>
-        set((state) => ({
-          attachedFiles: state.attachedFiles.filter((_, i) => i !== index),
-        })),
-      updateFileProgress: (index: number, progress: number) =>
-        set((state) => ({
-          attachedFiles: state.attachedFiles.map((file, i) =>
-            i === index ? { ...file, progress } : file,
-          ),
-        })),
-      updateFileError: (index: number, error: string) =>
-        set((state) => ({
-          attachedFiles: state.attachedFiles.map((file, i) =>
-            i === index ? { ...file, error } : file,
-          ),
-        })),
-      updateFileAttachmentId: (index: number, attachmentId: string) =>
-        set((state) => ({
-          attachedFiles: state.attachedFiles.map((file, i) =>
-            i === index ? { ...file, attachmentId } : file,
-          ),
-        })),
-      clearFiles: () => set({ attachedFiles: [] }),
+        set((state) => {
+          const updatedFiles = state.attachedFiles.filter(
+            (_, i) => i !== index,
+          );
+
+          // Sync to sessionStorage
+          if (updatedFiles.length > 0) {
+            const serializedFiles = updatedFiles.map(
+              async (af: AttachedFile) => {
+                const arrayBuffer = await af.file.arrayBuffer();
+                const uint8Array = new Uint8Array(arrayBuffer);
+                const data = btoa(String.fromCharCode(...uint8Array));
+
+                return {
+                  name: af.file.name,
+                  size: af.file.size,
+                  type: af.file.type,
+                  lastModified: af.file.lastModified,
+                  data,
+                  progress: af.progress,
+                  error: af.error,
+                  attachmentId: af.attachmentId,
+                };
+              },
+            );
+
+            Promise.all(serializedFiles).then((files) => {
+              sessionStorage.setItem(
+                "pendingAttachments",
+                JSON.stringify(files),
+              );
+            });
+          } else {
+            sessionStorage.removeItem("pendingAttachments");
+          }
+
+          return { attachedFiles: updatedFiles };
+        }),
+      clearFiles: () => {
+        sessionStorage.removeItem("pendingAttachments");
+        set({ attachedFiles: [] });
+      },
+      getPendingAttachments: () => {
+        const serialized = sessionStorage.getItem("pendingAttachments");
+        return serialized ? JSON.parse(serialized) : [];
+      },
     }),
     {
       name: "input-store",
@@ -71,15 +126,13 @@ export const inputStore = createStore(
       partialize: (state) => ({
         input: state.input,
         disabled: state.disabled,
-        attachedFiles: [],
+        attachedFiles: [], // Files will be handled separately via sessionStorage
         setInput: state.setInput,
         setDisabled: state.setDisabled,
-        addFiles: state.addFiles,
+        setFiles: state.setFiles,
         removeFile: state.removeFile,
-        updateFileProgress: state.updateFileProgress,
-        updateFileError: state.updateFileError,
-        updateFileAttachmentId: state.updateFileAttachmentId,
         clearFiles: state.clearFiles,
+        getPendingAttachments: state.getPendingAttachments,
       }),
     },
   ),

--- a/apps/web/src/hooks/use-file-attachments.ts
+++ b/apps/web/src/hooks/use-file-attachments.ts
@@ -45,7 +45,7 @@ export function useFileAttachments() {
   }, [attachedFiles]);
 
   const handleFilesSelected = useCallback((files: File[]) => {
-    inputStore.getState().addFiles(files);
+    inputStore.getState().setFiles(files);
   }, []);
 
   const handleRemoveFileById = useCallback((fileId: string) => {

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -1,3 +1,5 @@
+export type InputModality = "text" | "image";
+
 export interface Model {
   readonly id: number;
   readonly name: string;
@@ -6,6 +8,7 @@ export interface Model {
   readonly company: CompanyKey;
   readonly premium: boolean;
   readonly reasoningEffort: boolean;
+  readonly inputModalities: readonly InputModality[];
   readonly isDefault?: boolean;
   readonly recentlyUpdated?: boolean;
 }
@@ -129,6 +132,11 @@ export const getModelsByProvider = (provider: string): readonly Model[] =>
 export const isValidModelId = (id: number): boolean =>
   models.some((model) => model.id === id);
 
+export const supportsModality = (
+  model: Model,
+  modality: InputModality,
+): boolean => model.inputModalities.includes(modality);
+
 export const models: readonly Model[] = [
   {
     id: 1,
@@ -138,6 +146,7 @@ export const models: readonly Model[] = [
     company: "google",
     premium: false,
     reasoningEffort: false,
+    inputModalities: ["text", "image"],
     isDefault: true,
   },
   {
@@ -148,6 +157,7 @@ export const models: readonly Model[] = [
     company: "google",
     premium: false,
     reasoningEffort: false,
+    inputModalities: ["text", "image"],
   },
   {
     id: 3,
@@ -157,6 +167,7 @@ export const models: readonly Model[] = [
     company: "google",
     premium: false,
     reasoningEffort: false,
+    inputModalities: ["text", "image"],
     isDefault: false,
     recentlyUpdated: true,
   },
@@ -168,6 +179,7 @@ export const models: readonly Model[] = [
     company: "google",
     premium: false,
     reasoningEffort: false,
+    inputModalities: ["text", "image"],
     recentlyUpdated: true,
   },
   {
@@ -178,6 +190,7 @@ export const models: readonly Model[] = [
     company: "google",
     premium: false,
     reasoningEffort: true,
+    inputModalities: ["text", "image"],
     recentlyUpdated: true,
   },
   {
@@ -188,6 +201,7 @@ export const models: readonly Model[] = [
     company: "anthropic",
     premium: true,
     reasoningEffort: false,
+    inputModalities: ["text", "image"],
   },
   {
     id: 7,
@@ -197,6 +211,7 @@ export const models: readonly Model[] = [
     company: "openai",
     premium: false,
     reasoningEffort: false,
+    inputModalities: ["text", "image"],
   },
   {
     id: 8,
@@ -206,5 +221,6 @@ export const models: readonly Model[] = [
     company: "openai",
     premium: false,
     reasoningEffort: true,
+    inputModalities: ["text"],
   },
 ] as const;


### PR DESCRIPTION
### TL;DR

Improved file attachment handling for chat messages by storing attachments in sessionStorage and ensuring they persist through chat creation.

### What changed?

- Refactored the file attachment handling system to use sessionStorage for storing pending attachments
- Added a new `SerializedAttachedFile` interface to properly handle file serialization
- Modified the input store to include methods for managing serialized files:
  - Replaced `addFiles` with `setFiles` that also handles serialization
  - Added `getPendingAttachments` to retrieve serialized files from sessionStorage
  - Simplified file management by removing individual update methods
- Updated the chat input and chat view components to use the new attachment system
- Enhanced the `append` function in `use-chat.ts` to accept attachments as a parameter
- Added input modality support to the model definitions to track which models support text/image inputs

### How to test?

1. Start a new chat and attach files
2. Send a message with attachments
3. Verify that attachments are properly sent with the message
4. Test the flow of creating a new chat with attachments
5. Verify that attachments persist through the chat creation process

### Why make this change?

The previous implementation had issues with file attachments not being properly persisted when creating a new chat. This change ensures that file attachments are properly serialized, stored in sessionStorage, and available throughout the chat creation process. It also simplifies the file management code by centralizing the serialization logic and reducing the number of methods needed to manage file state.