### PR TITLE
chore: update claude hooks

### DIFF
--- a/.claude/hooks/bash-logger.sh
+++ b/.claude/hooks/bash-logger.sh
@@ -3,9 +3,11 @@
 # Bash Command Logger Hook
 # Logs all bash commands executed by Claude Code with session tracking
 
-LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/bash-commands.log"
+# Get the project root directory (where .git is located)
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+LOG_FILE="$PROJECT_ROOT/.claude/logs/bash-commands.log"
 TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-SESSION_TRACKER="$HOME/Documents/startup/openyap/openyap/.claude/hooks/session-tracker.sh"
+SESSION_TRACKER="$PROJECT_ROOT/.claude/hooks/session-tracker.sh"
 
 # Ensure log file exists
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -30,7 +32,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     echo "----------------------------------------" >> "$LOG_FILE"
     
     # Also log to a JSON file for easier parsing
-    JSON_LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/bash-commands.json"
+    JSON_LOG_FILE="$PROJECT_ROOT/.claude/logs/bash-commands.json"
     
     # Create JSON entry
     JSON_ENTRY=$(jq -n \

--- a/.claude/hooks/format-code.sh
+++ b/.claude/hooks/format-code.sh
@@ -3,7 +3,9 @@
 # Code Formatter Hook
 # Automatically formats code after file edits using Biome
 
-SESSION_TRACKER="$HOME/Documents/startup/openyap/openyap/.claude/hooks/session-tracker.sh"
+# Get the project root directory (where .git is located)
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+SESSION_TRACKER="$PROJECT_ROOT/.claude/hooks/session-tracker.sh"
 
 # Read the tool input from stdin
 TOOL_INPUT=$(cat)
@@ -39,20 +41,20 @@ if [ "$SHOULD_FORMAT" = true ]; then
     sleep 0.1
     
     # Change to the project root
-    cd "$HOME/Documents/startup/openyap/openyap" || exit
+    cd "$PROJECT_ROOT" || exit
     
     # Run Biome format on the specific file
     echo "Running Biome formatter on $FILE_PATH..." >&2
     
     # Get relative path from project root for Biome
-    RELATIVE_PATH=${FILE_PATH#"$HOME/Documents/startup/openyap/openyap/"}
+    RELATIVE_PATH=${FILE_PATH#"$PROJECT_ROOT/"}
     
     # Run the formatter from project root
     pnpm biome format --write "$RELATIVE_PATH" 2>&1 >&2
     
     # Log the formatting action
     TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-    LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/formatting.log"
+    LOG_FILE="$PROJECT_ROOT/.claude/logs/formatting.log"
     mkdir -p "$(dirname "$LOG_FILE")"
     echo "[$TIMESTAMP] Formatted: $FILE_PATH" >> "$LOG_FILE"
 fi

--- a/.claude/hooks/lint-check.sh
+++ b/.claude/hooks/lint-check.sh
@@ -29,14 +29,17 @@ if [ "$SHOULD_LINT" = true ]; then
     # Wait a moment for the file to be written
     sleep 0.2
     
+    # Get the project root directory (where .git is located)
+    PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+    
     # Change to the project root
-    cd "$HOME/Documents/startup/openyap/openyap" || exit
+    cd "$PROJECT_ROOT" || exit
     
     # Run Biome lint check on the specific file
     echo "Running Biome lint check on $FILE_PATH..." >&2
     
     # Get relative path from project root for Biome
-    RELATIVE_PATH=${FILE_PATH#"$HOME/Documents/startup/openyap/openyap/"}
+    RELATIVE_PATH=${FILE_PATH#"$PROJECT_ROOT/"}
     
     # Capture lint output
     LINT_OUTPUT=$(pnpm biome check "$RELATIVE_PATH" 2>&1)
@@ -44,7 +47,7 @@ if [ "$SHOULD_LINT" = true ]; then
     
     # Log the result
     TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-    LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/lint-results.log"
+    LOG_FILE="$PROJECT_ROOT/.claude/logs/lint-results.log"
     mkdir -p "$(dirname "$LOG_FILE")"
     
     if [ $LINT_EXIT_CODE -eq 0 ]; then
@@ -57,7 +60,7 @@ if [ "$SHOULD_LINT" = true ]; then
         echo "$LINT_OUTPUT" >&2
         
         # Also log to JSON for easier parsing
-        JSON_LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/lint-issues.json"
+        JSON_LOG_FILE="$PROJECT_ROOT/.claude/logs/lint-issues.json"
         JSON_ENTRY=$(jq -n \
             --arg ts "$TIMESTAMP" \
             --arg file "$FILE_PATH" \

--- a/.claude/hooks/performance-monitor.sh
+++ b/.claude/hooks/performance-monitor.sh
@@ -3,8 +3,10 @@
 # Performance Monitor Hook
 # Tracks command execution time and system resource usage
 
-PERF_LOG="$HOME/Documents/startup/openyap/openyap/.claude/logs/performance.log"
-PERF_JSON="$HOME/Documents/startup/openyap/openyap/.claude/logs/performance.json"
+# Get the project root directory (where .git is located)
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+PERF_LOG="$PROJECT_ROOT/.claude/logs/performance.log"
+PERF_JSON="$PROJECT_ROOT/.claude/logs/performance.json"
 
 # Ensure log directory exists
 mkdir -p "$(dirname "$PERF_LOG")"
@@ -149,7 +151,7 @@ if [ -n "$JSON_ENTRY" ]; then
 fi
 
 # Weekly performance summary (run on first execution of each week)
-WEEK_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/last-summary-week"
+WEEK_FILE="$PROJECT_ROOT/.claude/logs/last-summary-week"
 CURRENT_WEEK=$(date +%Y%U)
 
 if [ ! -f "$WEEK_FILE" ] || [ "$(cat "$WEEK_FILE" 2>/dev/null)" != "$CURRENT_WEEK" ]; then
@@ -157,7 +159,7 @@ if [ ! -f "$WEEK_FILE" ] || [ "$(cat "$WEEK_FILE" 2>/dev/null)" != "$CURRENT_WEE
     
     # Generate weekly summary
     if [ -f "$PERF_JSON" ]; then
-        WEEKLY_SUMMARY="$HOME/Documents/startup/openyap/openyap/.claude/logs/weekly-performance.log"
+        WEEKLY_SUMMARY="$PROJECT_ROOT/.claude/logs/weekly-performance.log"
         TOTAL_OPERATIONS=$(jq 'length' "$PERF_JSON" 2>/dev/null || echo "0")
         HIGH_COMPLEXITY=$(jq '[.[] | select(.complexity == "high")] | length' "$PERF_JSON" 2>/dev/null || echo "0")
         

--- a/.claude/hooks/safety-check.sh
+++ b/.claude/hooks/safety-check.sh
@@ -60,7 +60,8 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     if [[ "$COMMAND" =~ (rm|mv|cp).*(/etc/|/var/|/usr/bin/|/usr/sbin/) ]]; then
         echo "WARNING: Operation on system directory detected!" >&2
         TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-        LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/safety-warnings.log"
+        PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+        LOG_FILE="$PROJECT_ROOT/.claude/logs/safety-warnings.log"
         mkdir -p "$(dirname "$LOG_FILE")"
         echo "[$TIMESTAMP] System directory operation: $COMMAND" >> "$LOG_FILE"
     fi
@@ -70,7 +71,8 @@ if [ "$TOOL_NAME" = "Bash" ]; then
         echo "WARNING: Git operation on protected branch detected. Proceed with caution!" >&2
         # Log the warning
         TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-        LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/safety-warnings.log"
+        PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+        LOG_FILE="$PROJECT_ROOT/.claude/logs/safety-warnings.log"
         mkdir -p "$(dirname "$LOG_FILE")"
         echo "[$TIMESTAMP] Git operation on protected branch: $COMMAND" >> "$LOG_FILE"
     fi
@@ -79,7 +81,8 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     if [[ "$COMMAND" =~ ^sudo\ |\ sudo\  ]]; then
         echo "WARNING: Sudo command detected. This requires elevated privileges!" >&2
         TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-        LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/safety-warnings.log"
+        PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+        LOG_FILE="$PROJECT_ROOT/.claude/logs/safety-warnings.log"
         echo "[$TIMESTAMP] Sudo command: $COMMAND" >> "$LOG_FILE"
     fi
     
@@ -87,7 +90,8 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     if [[ "$COMMAND" =~ npm\ install\ -g|pip\ install\ --global|brew\ install ]]; then
         echo "INFO: System-wide installation detected" >&2
         TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-        LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/safety-warnings.log"
+        PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+        LOG_FILE="$PROJECT_ROOT/.claude/logs/safety-warnings.log"
         echo "[$TIMESTAMP] System installation: $COMMAND" >> "$LOG_FILE"
     fi
     
@@ -95,7 +99,8 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     if [[ "$COMMAND" =~ curl.*-o.*\||wget.*-O.*\||nc\ -l ]]; then
         echo "WARNING: Potentially risky network operation detected!" >&2
         TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-        LOG_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/safety-warnings.log"
+        PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+        LOG_FILE="$PROJECT_ROOT/.claude/logs/safety-warnings.log"
         echo "[$TIMESTAMP] Network operation: $COMMAND" >> "$LOG_FILE"
     fi
     

--- a/.claude/hooks/session-summary.sh
+++ b/.claude/hooks/session-summary.sh
@@ -3,9 +3,11 @@
 # Session Summary Hook
 # Generates a summary of all changes made during the session
 
-SUMMARY_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/session-summary.log"
+# Get the project root directory (where .git is located)
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+SUMMARY_FILE="$PROJECT_ROOT/.claude/logs/session-summary.log"
 TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
-SESSION_TRACKER="$HOME/Documents/startup/openyap/openyap/.claude/hooks/session-tracker.sh"
+SESSION_TRACKER="$PROJECT_ROOT/.claude/hooks/session-tracker.sh"
 
 # Ensure log directory exists
 mkdir -p "$(dirname "$SUMMARY_FILE")"
@@ -18,7 +20,7 @@ bash "$SESSION_TRACKER" end
 SESSION_DATA=$(bash "$SESSION_TRACKER" get-data)
 
 # Change to project directory
-cd "$HOME/Documents/startup/openyap/openyap" || exit
+cd "$PROJECT_ROOT" || exit
 
 # Start summary
 echo "========================================" >> "$SUMMARY_FILE"
@@ -50,7 +52,7 @@ fi
 
 # Summary of bash commands executed (if log exists)
 COMMAND_COUNT="0"
-BASH_LOG="$HOME/Documents/startup/openyap/openyap/.claude/logs/bash-commands.log"
+BASH_LOG="$PROJECT_ROOT/.claude/logs/bash-commands.log"
 if [ -f "$BASH_LOG" ]; then
     # Count today's commands
     TODAY=$(date -u +"%Y-%m-%d")
@@ -60,7 +62,7 @@ fi
 
 # Check for lint issues
 LINT_FAILS="0"
-LINT_LOG="$HOME/Documents/startup/openyap/openyap/.claude/logs/lint-results.log"
+LINT_LOG="$PROJECT_ROOT/.claude/logs/lint-results.log"
 if [ -f "$LINT_LOG" ]; then
     TODAY=$(date -u +"%Y-%m-%d")
     LINT_FAILS=$(grep "^\[$TODAY.*FAIL:" "$LINT_LOG" 2>/dev/null | wc -l | tr -d ' ')
@@ -71,7 +73,7 @@ fi
 
 # Safety warnings
 WARNING_COUNT="0"
-SAFETY_LOG="$HOME/Documents/startup/openyap/openyap/.claude/logs/safety-warnings.log"
+SAFETY_LOG="$PROJECT_ROOT/.claude/logs/safety-warnings.log"
 if [ -f "$SAFETY_LOG" ]; then
     TODAY=$(date -u +"%Y-%m-%d")
     WARNING_COUNT=$(grep -c "^\[$TODAY" "$SAFETY_LOG" 2>/dev/null || echo "0")
@@ -81,7 +83,7 @@ if [ -f "$SAFETY_LOG" ]; then
 fi
 
 # Create a JSON summary for programmatic access
-JSON_SUMMARY="$HOME/Documents/startup/openyap/openyap/.claude/logs/session-summary.json"
+JSON_SUMMARY="$PROJECT_ROOT/.claude/logs/session-summary.json"
 JSON_ENTRY=$(jq -n \
     --arg ts "$TIMESTAMP" \
     --arg modified "$MODIFIED_COUNT" \

--- a/.claude/hooks/session-tracker.sh
+++ b/.claude/hooks/session-tracker.sh
@@ -3,8 +3,10 @@
 # Session Tracker Utility
 # Manages Claude Code session tracking with unique IDs
 
-SESSION_FILE="$HOME/Documents/startup/openyap/openyap/.claude/logs/current-session.txt"
-SESSION_LOG="$HOME/Documents/startup/openyap/openyap/.claude/logs/sessions.json"
+# Get the project root directory (where .git is located)
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+SESSION_FILE="$PROJECT_ROOT/.claude/logs/current-session.txt"
+SESSION_LOG="$PROJECT_ROOT/.claude/logs/sessions.json"
 
 # Ensure log directory exists
 mkdir -p "$(dirname "$SESSION_FILE")"

--- a/.claude/hooks/todo-tracker.sh
+++ b/.claude/hooks/todo-tracker.sh
@@ -3,7 +3,9 @@
 # Todo Tracker Hook
 # Captures TodoWrite tool usage and logs todos to session tracker
 
-SESSION_TRACKER="$HOME/Documents/startup/openyap/openyap/.claude/hooks/session-tracker.sh"
+# Get the project root directory (where .git is located)
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "$(pwd)")
+SESSION_TRACKER="$PROJECT_ROOT/.claude/hooks/session-tracker.sh"
 
 # Read the tool input from stdin
 TOOL_INPUT=$(cat)

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .turbo
 .DS_Store
 .claude/logs
+.claude/.discord-webhook
 node_modules
 package-lock.json
 yarn.lock


### PR DESCRIPTION
### TL;DR

Refactored Claude hooks to use dynamic project root detection instead of hardcoded paths.

### What changed?

- Replaced all hardcoded paths with dynamic project root detection using `git rev-parse --show-toplevel`
- Improved Discord webhook configuration to use a project-specific config file (`.claude/.discord-webhook`)
- Enhanced file change reporting in Discord notifications to show edit counts per file
- Reduced the number of recent commands and todos shown in Discord notifications from 5 to 3
- Added `.claude/.discord-webhook` to `.gitignore` to keep webhook URLs private

### How to test?

1. Clone the repository to a different location and verify hooks work correctly
2. Create a `.claude/.discord-webhook` file with your Discord webhook URL
3. Run some commands and verify logs are created in the correct location
4. Check Discord notifications to confirm they show proper file paths and edit counts

### Why make this change?

This change makes the Claude hooks more portable and secure by:
- Eliminating hardcoded paths that were specific to one developer's environment
- Improving security by moving the Discord webhook URL to a gitignored config file
- Making the hooks work correctly regardless of where the repository is cloned
- Providing more useful information in Discord notifications about file edit frequency