### PR TITLE
fix(web): enable scan toolbar only in development mode

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -60,8 +60,7 @@ function RootComponent() {
 function RootDocument({ children }: { readonly children: React.ReactNode }) {
   useEffect(() => {
     scan({
-      enabled: true,
-      showToolbar: true,
+      enabled: process.env.NODE_ENV === "development",
     });
   }, []);
 


### PR DESCRIPTION
### TL;DR

Simplified the scan configuration to only enable it in development environments.

### What changed?

Modified the scan configuration in `apps/web/src/routes/__root.tsx` to conditionally enable scanning based on the environment. Removed the `showToolbar: true` property and replaced the hardcoded `enabled: true` with a check that only enables scanning when `NODE_ENV` is set to "development".

### How to test?

1. Run the application in development mode and verify that scanning works as expected
2. Run the application in production mode and confirm that scanning is disabled

### Why make this change?

This change ensures that scanning only runs in development environments, which improves production performance and prevents unnecessary scanning in production builds. This is a best practice for development tools that aren't needed in production.