### PR TITLE
fix(web): duplicate reasoning steps

### DIFF
--- a/apps/web/src/components/chat/blocks/link-block.tsx
+++ b/apps/web/src/components/chat/blocks/link-block.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "lucide-react";
 import type { Tokens } from "marked";
 import { TokenBlock } from "~/components/chat/blocks/token-block";
 import { getTokenKey } from "~/lib/utils";
@@ -10,14 +11,17 @@ export function LinkBlock({ token }: LinkBlockProps) {
   return (
     <a
       href={token.href}
-      className="text-primary underline hover:text-primary/80"
+      className="group inline-flex items-end gap-1 rounded-sm text-primary underline-offset-4 transition-all hover:text-primary/80 hover:underline focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
       target="_blank"
       rel="noopener noreferrer"
       {...(token.title && { title: token.title })}
     >
-      {token.tokens.map((subToken, index) => (
-        <TokenBlock key={getTokenKey(subToken, index)} token={subToken} />
-      ))}
+      <span className="inline-flex items-center">
+        {token.tokens.map((subToken, index) => (
+          <TokenBlock key={getTokenKey(subToken, index)} token={subToken} />
+        ))}
+      </span>
+      <ExternalLink className="size-3.5 shrink-0 opacity-60 transition-opacity group-hover:opacity-100" />
     </a>
   );
 }

--- a/apps/web/src/hooks/use-chat.ts
+++ b/apps/web/src/hooks/use-chat.ts
@@ -106,6 +106,8 @@ export function useChat(chatId: string | undefined) {
           duration: 0,
           reasoningEffort: reasoningEffort,
         };
+        // This is used to avoid duplicate reasoning parts
+        let lastReasoningPart = "";
 
         await processDataStream({
           stream: response.body,
@@ -125,7 +127,10 @@ export function useChat(chatId: string | undefined) {
           },
           onReasoningPart(value) {
             setStatus(ChatStatus.STREAMING);
-            reasoningBuffer.text += value;
+            if (value !== lastReasoningPart) {
+              reasoningBuffer.text += value;
+              lastReasoningPart = value;
+            }
 
             const steps = splitReasoningSteps(reasoningBuffer.text).map(
               (step) => ({ text: step }),


### PR DESCRIPTION
### TL;DR

Enhanced link styling with external link icon and fixed duplicate reasoning parts in chat streams.

### What changed?

- Added an external link icon from Lucide to link blocks in chat
- Improved link styling with better focus states and hover effects
- Fixed an issue where reasoning parts were being duplicated in chat streams by tracking the last reasoning part/delta
- Added checks to prevent duplicate reasoning content from being added to the buffer

### How to test?

1. Open a chat and observe links in the chat messages
2. Verify that links now display an external link icon
3. Check that the hover and focus states for links work correctly
4. Start a new chat with reasoning enabled and verify that reasoning steps are displayed without duplications

### Why make this change?

- The external link icon improves UX by making it clear which links will open in a new tab
- The improved styling enhances accessibility with better focus states
- The fix for duplicate reasoning parts prevents redundant content in the reasoning buffer, making the reasoning output cleaner and more accurate