### PR TITLE
feat(web): sidebar ui enhancements

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -71,7 +71,7 @@ export function AppSidebar() {
                     navigate({ to: "/" });
                   }}
                   tooltip="New Chat"
-                  className="bg-primary text-primary-foreground hover:bg-primary/80 hover:text-primary-foreground"
+                  className="cursor-pointer bg-primary text-primary-foreground hover:bg-primary/80 hover:text-primary-foreground"
                 >
                   <Plus className="h-4 w-4" />
                   <span>New Chat</span>

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps, cva } from "class-variance-authority";
-import { PanelLeftIcon } from "lucide-react";
+import { ArrowLeftToLine, ArrowRightToLine, PanelLeftIcon } from "lucide-react";
 import * as React from "react";
 
 import { Button } from "~/components/ui/button";
@@ -170,7 +170,8 @@ function Sidebar({
   variant?: "sidebar" | "floating" | "inset";
   collapsible?: "offcanvas" | "icon" | "none";
 }) {
-  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+  const { isMobile, state, openMobile, setOpenMobile, toggleSidebar } =
+    useSidebar();
 
   if (collapsible === "none") {
     return (
@@ -251,7 +252,25 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm"
+          className={cn(
+            "flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm",
+            state === "collapsed" &&
+              "cursor-pointer transition-colors duration-200 hover:bg-sidebar-accent",
+          )}
+          onClick={state === "collapsed" ? toggleSidebar : undefined}
+          role={state === "collapsed" ? "button" : undefined}
+          aria-label={state === "collapsed" ? "Expand Sidebar" : undefined}
+          tabIndex={state === "collapsed" ? 0 : undefined}
+          onKeyDown={
+            state === "collapsed"
+              ? (e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    toggleSidebar();
+                  }
+                }
+              : undefined
+          }
         >
           {children}
         </div>
@@ -265,7 +284,8 @@ function SidebarTrigger({
   onClick,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, state } = useSidebar();
+  const [isHovered, setIsHovered] = React.useState(false);
 
   return (
     <Button
@@ -273,14 +293,34 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon"
-      className={cn("size-7", className)}
+      className={cn("group size-7", className)}
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
       }}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
       {...props}
     >
-      <PanelLeftIcon />
+      <PanelLeftIcon
+        className={cn(
+          "transition-opacity duration-200",
+          state === "collapsed" && "group-hover:opacity-0",
+          state === "expanded" && isHovered && "opacity-0",
+        )}
+      />
+      <ArrowRightToLine
+        className={cn(
+          "absolute opacity-0 transition-opacity duration-200",
+          state === "collapsed" && "group-hover:opacity-100",
+        )}
+      />
+      <ArrowLeftToLine
+        className={cn(
+          "absolute opacity-0 transition-opacity duration-200",
+          state === "expanded" && isHovered && "opacity-100",
+        )}
+      />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );

--- a/apps/web/src/hooks/use-chat.ts
+++ b/apps/web/src/hooks/use-chat.ts
@@ -40,7 +40,9 @@ export function useChat(chatId: string | undefined) {
   const [status, setStatus] = useState<ChatStatus>(ChatStatus.IDLE);
   const [abortController, setAbortController] =
     useState<AbortController | null>(null);
-  const [currentChatId, setCurrentChatId] = useState<string | undefined>(chatId);
+  const [currentChatId, setCurrentChatId] = useState<string | undefined>(
+    chatId,
+  );
 
   const updateAiMessage = useMutation(api.functions.message.updateAiMessage);
   const getChatMessages = useQuery(
@@ -65,7 +67,11 @@ export function useChat(chatId: string | undefined) {
 
   // Update messages when query data changes
   useEffect(() => {
-    if (getChatMessages && status !== ChatStatus.STREAMING && chatId === currentChatId) {
+    if (
+      getChatMessages &&
+      status !== ChatStatus.STREAMING &&
+      chatId === currentChatId
+    ) {
       setMessages(getChatMessages);
     }
   }, [getChatMessages, status, chatId, currentChatId]);


### PR DESCRIPTION
### TL;DR

Enhanced sidebar UX with improved collapse/expand functionality and added cursor feedback for better user interaction.

### What changed?

- Added `cursor-pointer` class to the "New Chat" button in the app sidebar
- Enhanced the sidebar component with visual feedback when collapsed:
  - Added hover background color effect for collapsed state
  - Made the collapsed sidebar clickable to expand it
  - Added keyboard accessibility (Enter/Space) to expand the sidebar
  - Added proper ARIA attributes for accessibility
- Improved the sidebar trigger button with animated icons:
  - Added transition effects between PanelLeftIcon, ArrowLeftToLine, and ArrowRightToLine
  - Icons now change on hover to indicate the action (expand/collapse)
- Fixed code formatting in the `use-chat.ts` file

### How to test?

1. Collapse the sidebar and verify that:
   - The sidebar shows a hover effect when mouse is over it
   - Clicking on the collapsed sidebar expands it
   - Pressing Enter or Space when focused on the collapsed sidebar expands it
2. Hover over the sidebar trigger button and verify that:
   - The icon changes to indicate the action (expand when collapsed, collapse when expanded)
   - The transition between icons is smooth
3. Click the "New Chat" button and verify the cursor changes to a pointer

### Why make this change?

These improvements enhance the user experience by providing better visual feedback and interaction cues. The changes make the sidebar more intuitive to use, especially in its collapsed state, and improve accessibility by adding keyboard navigation and proper ARIA attributes. The animated icons provide clearer indication of the available actions.