### PR TITLE
feat(web): create math tool

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,6 +52,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.513.0",
     "marked": "15.0.12",
+    "mathjs": "^14.6.0",
     "motion": "12.19.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/apps/web/src/lib/ai/mathEvaluation.ts
+++ b/apps/web/src/lib/ai/mathEvaluation.ts
@@ -1,0 +1,77 @@
+import { tool } from "ai";
+import { Effect } from "effect";
+import { pipe } from "effect/Function";
+import { evaluate, parse } from "mathjs";
+import { z } from "zod";
+import { UI_CONSTANTS } from "~/lib/constants";
+import { logger } from "~/lib/logger";
+
+type MathResult = {
+  expression: string;
+  result: string;
+  isValid: boolean;
+  error?: string;
+};
+
+export const mathEvaluation = tool({
+  description:
+    "Evaluate mathematical expressions (NOT equations). Only use for expressions that can be computed to a single numeric result.",
+  parameters: z
+    .object({
+      expression: z
+        .string()
+        .min(1)
+        .max(UI_CONSTANTS.TITLE_LIMITS.MAX_LENGTH)
+        .describe(
+          "A mathematical expression to evaluate. Examples: '2 + 2', 'sqrt(16)', 'sin(pi/2)', 'log(100)', '5*6-3'. Do NOT use for equations with '=' or unknowns like 'x'."
+        ),
+    })
+    .strict(),
+  execute: async ({ expression }): Promise<MathResult> => {
+    logger.info(`Evaluating math expression: "${expression}"`);
+
+    const evaluateEffect = Effect.tryPromise({
+      try: async () => {
+        const _parsed = parse(expression);
+
+        const result = evaluate(expression);
+
+        return {
+          expression,
+          result: String(result),
+          isValid: true,
+        };
+      },
+      catch: (err) => {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+
+        let helpfulError = errorMessage;
+        if (errorMessage.includes("assignment operator =")) {
+          helpfulError =
+            "Cannot evaluate equations with '='. Use mathEvaluation only for expressions that compute to a number (e.g., '3*7-1' instead of '3x+7=22').";
+        } else if (errorMessage.includes("Undefined symbol")) {
+          helpfulError = `${errorMessage}. Variables like 'x' cannot be evaluated. Use mathEvaluation only for numeric expressions.`;
+        }
+
+        return {
+          expression,
+          result: "",
+          isValid: false,
+          error: helpfulError,
+        };
+      },
+    });
+
+    const transformEffect = pipe(
+      evaluateEffect,
+      Effect.map((result: MathResult) => {
+        if (result.result.length > UI_CONSTANTS.POLLING_INTERVALS.SLOW_UPDATE) {
+          result.result = `${result.result.slice(0, UI_CONSTANTS.POLLING_INTERVALS.SLOW_UPDATE)}...`;
+        }
+        return result;
+      })
+    );
+
+    return Effect.runPromise(transformEffect);
+  },
+});

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -82,10 +82,19 @@ export const getSystemPrompt = (
     "- For text formatting, only use markdown formatting.",
   ];
 
+  // Add tool-use instructions
+  directives.push(
+    "\n",
+    "Tool-use rules (read carefully):",
+    "- Use mathEvaluation ONLY for mathematical expressions that can be computed to a single numeric result.",
+    "- Examples of what to use mathEvaluation for: '2 + 2', 'sqrt(16)', 'sin(pi/2)', 'log(100)', '5*6-3'.",
+    "- Do NOT use mathEvaluation for equations (expressions with '='), unknowns (like 'x'), or word problems.",
+    "- For equations like '3x + 7 = 22', solve them algebraically and then use mathEvaluation to verify intermediate steps.",
+    "- Break complex problems into computable parts: first solve algebraically, then verify with mathEvaluation.",
+  );
+
   if (searchEnabled) {
     directives.push(
-      "\n",
-      "Tool-use rules (read carefully):",
       "- You may call webSearch at most ONCE per response.",
       "- After receiving the JSON result, immediately answer the user. Do NOT call any tool again.",
       "- If you are at least 70 % confident you already know the answer, skip the tool.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       marked:
         specifier: 15.0.12
         version: 15.0.12
+      mathjs:
+        specifier: ^14.6.0
+        version: 14.6.0
       motion:
         specifier: 12.19.1
         version: 12.19.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2374,6 +2377,9 @@ packages:
   compatx@0.2.0:
     resolution: {integrity: sha512-6gLRNt4ygsi5NyMVhceOCFv14CIdDFN7fQjX1U4+47qVE/+kjPoXMK65KWK+dWxmFzMTuKazoQ9sch6pM0p5oA==}
 
+  complex.js@2.4.2:
+    resolution: {integrity: sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==}
+
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
@@ -2499,6 +2505,9 @@ packages:
 
   decache@4.6.2:
     resolution: {integrity: sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -2702,6 +2711,9 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-latex@1.2.0:
+    resolution: {integrity: sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
@@ -2829,6 +2841,10 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  fraction.js@5.2.2:
+    resolution: {integrity: sha512-uXBDv5knpYmv/2gLzWQ5mBHGBRk9wcKTeWu6GLTUEQfjCxO09uM/mHDrojlL+Q1mVGIIFo149Gba7od1XPgSzQ==}
+    engines: {node: '>= 12'}
 
   framer-motion@12.19.1:
     resolution: {integrity: sha512-nq9hwWAEKf4gzprbOZzKugLV5OVKF7zrNDY6UOVu+4D3ZgIkg8L9Jy6AMrpBM06fhbKJ6LEG6UY5+t7Eq6wNlg==}
@@ -3144,6 +3160,9 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  javascript-natural-sort@0.7.1:
+    resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
+
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
@@ -3344,6 +3363,11 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mathjs@14.6.0:
+    resolution: {integrity: sha512-5vI2BLB5GKQmiSK9BH6hVkZ+GgqpdnOgEfmHl7mqVmdQObLynr63KueyYYLCQMzj66q69mV2XZZGQqqxeftQbA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   merge-options@3.0.4:
     resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
@@ -3971,6 +3995,9 @@ packages:
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
+  seedrandom@3.0.5:
+    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4191,6 +4218,9 @@ packages:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
+  tiny-emitter@2.1.0:
+    resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -4286,6 +4316,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  typed-function@4.2.1:
+    resolution: {integrity: sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==}
+    engines: {node: '>= 18'}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -6927,6 +6961,8 @@ snapshots:
 
   compatx@0.2.0: {}
 
+  complex.js@2.4.2: {}
+
   compress-commons@6.0.2:
     dependencies:
       crc-32: 1.2.2
@@ -7016,6 +7052,8 @@ snapshots:
   decache@4.6.2:
     dependencies:
       callsite: 1.0.0
+
+  decimal.js@10.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -7242,6 +7280,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-latex@1.2.0: {}
+
   escape-string-regexp@5.0.0: {}
 
   escodegen@2.1.0:
@@ -7372,6 +7412,8 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  fraction.js@5.2.2: {}
 
   framer-motion@12.19.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -7680,6 +7722,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  javascript-natural-sort@0.7.1: {}
+
   jiti@2.4.2: {}
 
   jose@5.10.0: {}
@@ -7856,6 +7900,18 @@ snapshots:
   marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
+
+  mathjs@14.6.0:
+    dependencies:
+      '@babel/runtime': 7.27.6
+      complex.js: 2.4.2
+      decimal.js: 10.6.0
+      escape-latex: 1.2.0
+      fraction.js: 5.2.2
+      javascript-natural-sort: 0.7.1
+      seedrandom: 3.0.5
+      tiny-emitter: 2.1.0
+      typed-function: 4.2.1
 
   merge-options@3.0.4:
     dependencies:
@@ -8554,6 +8610,8 @@ snapshots:
 
   secure-json-parse@2.7.0: {}
 
+  seedrandom@3.0.5: {}
+
   semver@6.3.1: {}
 
   semver@7.7.2: {}
@@ -8788,6 +8846,8 @@ snapshots:
 
   throttleit@2.1.0: {}
 
+  tiny-emitter@2.1.0: {}
+
   tiny-invariant@1.3.3: {}
 
   tiny-warning@1.0.3: {}
@@ -8862,6 +8922,8 @@ snapshots:
   tw-animate-css@1.3.4: {}
 
   type-fest@4.41.0: {}
+
+  typed-function@4.2.1: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
This pull request introduces a new feature for evaluating mathematical expressions using the `mathjs` library, integrates it into the existing toolset, and updates the dependencies accordingly. The changes include the addition of a math evaluation tool, updates to system prompts, and modifications to the server route logic to incorporate the new tool.

### New Feature: Math Evaluation Tool
* Added a `mathEvaluation` tool in `apps/web/src/lib/ai/mathEvaluation.ts` to evaluate mathematical expressions using `mathjs`. The tool handles errors gracefully and provides detailed feedback for invalid inputs.
* Updated `apps/web/package.json` and `pnpm-lock.yaml` to include `mathjs` and its dependencies (`complex.js`, `decimal.js`, `escape-latex`, `fraction.js`, `javascript-natural-sort`, `seedrandom`, `tiny-emitter`, `typed-function`).

### Integration with Existing Features
* Updated `apps/web/src/lib/models.ts` to include instructions for using the `mathEvaluation` tool in system prompts. These instructions clarify its purpose and provide examples of valid and invalid use cases.
* Modified `apps/web/src/routes/api/chat.ts` to integrate the `mathEvaluation` tool into the server-side toolset, allowing it to be used alongside the `webSearch` tool. Adjusted the `maxSteps` parameter to accommodate the new tool.