### PR TITLE
Configure Cursor to use Biome formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,4 +12,18 @@
     "*.css": "tailwindcss"
   },
   "typescript.preferences.importModuleSpecifier": "non-relative",
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }


### PR DESCRIPTION
## TL;DR
Configured Cursor IDE to use Biome instead of Prettier for code formatting in this project.

## What changed?
- Added VS Code settings to `.vscode/settings.json` to set Biome as the default formatter
- Configured format-on-save to be enabled
- Set Biome as the formatter for JavaScript, TypeScript, JSON, and JSONC files
- Applied settings only to this workspace (project-specific)

## How to test?
1. Open the project in Cursor IDE
2. Make changes to any JS/TS/JSON file
3. Save the file (Ctrl/Cmd+S) and verify it formats using Biome rules
4. Use Format Document command and verify it uses Biome

## Why make this change?
This ensures consistent code formatting across the team using the project's chosen formatter (Biome) instead of Prettier, aligning with the existing toolchain and build process.