### PR TITLE
Fix MessageStatus import error causing crashes with reasoning models

### DIFF
--- a/apps/web/src/components/chat/message.tsx
+++ b/apps/web/src/components/chat/message.tsx
@@ -7,11 +7,8 @@ import { memo, useMemo, useState } from "react";
 import { ProfileAvatar } from "~/components/auth/profile-avatar";
 import { AttachmentList } from "~/components/chat/attachment-preview";
 import { TokenBlock } from "~/components/chat/blocks";
-import type {
-  ChatMessage,
-  MessageReasoning,
-  MessageStatus,
-} from "~/components/chat/types";
+import type { ChatMessage, MessageReasoning } from "~/components/chat/types";
+import { MessageStatus } from "~/components/chat/types";
 import { AnimatedShinyText } from "~/components/ui/animated-shiny-text";
 import { Button } from "~/components/ui/button";
 import {

--- a/apps/web/src/components/chat/message.tsx
+++ b/apps/web/src/components/chat/message.tsx
@@ -7,7 +7,11 @@ import { memo, useMemo, useState } from "react";
 import { ProfileAvatar } from "~/components/auth/profile-avatar";
 import { AttachmentList } from "~/components/chat/attachment-preview";
 import { TokenBlock } from "~/components/chat/blocks";
-import type { ChatMessage, MessageReasoning } from "~/components/chat/types";
+import type {
+  ChatMessage,
+  MessageReasoning,
+  MessageStatusType,
+} from "~/components/chat/types";
 import { MessageStatus } from "~/components/chat/types";
 import { AnimatedShinyText } from "~/components/ui/animated-shiny-text";
 import { Button } from "~/components/ui/button";
@@ -25,7 +29,7 @@ import { cn } from "~/lib/utils";
 
 interface ReasoningCollapsibleProps {
   readonly reasoning: MessageReasoning;
-  readonly status: MessageStatus;
+  readonly status: MessageStatusType;
 }
 
 function formatSeconds(duration: number) {


### PR DESCRIPTION
## TL;DR
Fixed a critical bug where reasoning models (o4-mini, gemini 2.5 pro) crashed the UI during streaming with "MessageStatus is not defined" error.

## What changed?
- Changed `MessageStatus` from type import to value import in `message.tsx`
- Updated `ReasoningCollapsibleProps` interface to use `MessageStatusType` instead of `MessageStatus` enum
- Fixed type mismatch between component prop expectations and actual database schema types

## How to test?
1. Start a new chat with a reasoning model (o4-mini or gemini 2.5 pro with any effort level)
2. Send a message that triggers reasoning
3. Verify the UI doesn't crash during the initial streaming phase
4. Confirm the reasoning collapsible component displays correctly
5. Check that after reload, the reasoning data persists without the thinking content

## Why make this change?
The original code imported `MessageStatus` as a type, but used it as a runtime value (`MessageStatus.REASONING`). TypeScript strips type imports at runtime, causing the reference error. Additionally, the component expected the enum type but received the database string type, causing type mismatches. This fix ensures reasoning models work seamlessly without UI crashes.