### PR TITLE
Fix graceful tool error and early stop handling

### DIFF
--- a/apps/web/src/lib/ai/mathEvaluation.ts
+++ b/apps/web/src/lib/ai/mathEvaluation.ts
@@ -59,6 +59,16 @@ export const mathEvaluation = tool({
             logger.warn(
               `Math evaluation failed - equation detected: "${expression}"`,
             );
+          } else if (errorMessage.includes("Undefined function")) {
+            if (expression.includes("ln(")) {
+              helpfulError =
+                "Function 'ln' is not available. Use 'log' for natural logarithm or 'log10' for base-10 logarithm.";
+            } else {
+              helpfulError = `${errorMessage}. Check the function name - common functions include: sin, cos, tan, log (natural), log10, sqrt, abs, exp.`;
+            }
+            logger.warn(
+              `Math evaluation failed - undefined function: "${expression}"`,
+            );
           } else if (errorMessage.includes("Undefined symbol")) {
             helpfulError = `${errorMessage}. Variables like 'x' cannot be evaluated. Use mathEvaluation only for numeric expressions.`;
             logger.warn(


### PR DESCRIPTION
## TL;DR
Fixed AI tool execution errors causing stream aborts and added graceful handling for early model stops.

## What changed?
- Enhanced math tool error handling with specific messages for common issues (e.g., ln() function)
- Added comprehensive streaming error handling to distinguish tool errors from fatal errors
- Implemented finish reason tracking and graceful completion for early stops
- Tool execution errors no longer abort the entire streaming response
- Added state tracking for tool errors and finish reasons in streaming pipeline
- Messages now complete gracefully even when model stops early due to tool failures

## How to test?
1. Start the development server with `pnpm dev`
2. Create a new chat and ask the model to evaluate `ln(1.5)`
3. Verify the math tool returns a helpful error message instead of crashing
4. Check that the streaming response completes normally despite the tool error
5. Monitor logs to see graceful error handling instead of stream aborts
6. Test other math expressions with errors to ensure robust handling

## Why make this change?
Previously, when AI tools like mathEvaluation encountered errors (e.g., undefined function `ln`), they would throw `AI_ToolExecutionError` which caused the entire streaming response to abort with alarming error messages. This created a poor user experience where conversations would fail unexpectedly due to minor tool issues. The fix ensures that tool failures are handled gracefully, conversations continue normally, and users receive helpful error messages instead of seeing the chat break.