### PR TITLE
feat: implement message editing functionality

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -76,6 +76,14 @@ export function ChatView() {
           <div className="mx-auto max-w-[752px] space-y-3 pt-5">
             <AnimatePresence initial={false}>
               {messages.map((m, index) => {
+                const handleMessageEdit = () => {
+                  // Only regenerate if this is a user message and not the last message
+                  if (m.role === "user" && index < messages.length - 1) {
+                    // Trigger AI regeneration with the edited message content
+                    append({ content: "" });
+                  }
+                };
+
                 if (
                   status === ChatStatus.STREAMING &&
                   index === messages.length - 1 &&
@@ -83,13 +91,21 @@ export function ChatView() {
                 )
                   return (
                     <MessageErrorBoundary key={m._id}>
-                      <Message data={m} user={session?.user} />
+                      <Message
+                        data={m}
+                        user={session?.user}
+                        onMessageEdit={handleMessageEdit}
+                      />
                     </MessageErrorBoundary>
                   );
 
                 return (
                   <MessageErrorBoundary key={m._id}>
-                    <MemoizedMessage data={m} user={session?.user} />
+                    <MemoizedMessage
+                      data={m}
+                      user={session?.user}
+                      onMessageEdit={handleMessageEdit}
+                    />
                   </MessageErrorBoundary>
                 );
               })}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -77,11 +77,11 @@ export function ChatView() {
           <div className="mx-auto max-w-[752px] space-y-3 pt-5">
             <AnimatePresence initial={false}>
               {messages.map((m, index) => {
-                const handleMessageEdit = () => {
+                const handleMessageEdit = (editedContent: string) => {
                   // Only regenerate if this is a user message
                   if (m.role === "user") {
-                    // Trigger AI regeneration from the edited message
-                    regenerate(m._id);
+                    // Trigger AI regeneration from the edited message with the new content
+                    regenerate(m._id, editedContent);
                   }
                 };
 

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -6,8 +6,8 @@ import { ChatInput } from "~/components/chat/chat-input";
 import { MemoizedMessage, Message } from "~/components/chat/message";
 import { ChatStatus, MessageStatus } from "~/components/chat/types";
 import {
-	ChatErrorBoundary,
-	MessageErrorBoundary,
+  ChatErrorBoundary,
+  MessageErrorBoundary,
 } from "~/components/error-boundary";
 import { Button } from "~/components/ui/button";
 import { useChat } from "~/hooks/use-chat";
@@ -18,129 +18,129 @@ import { authClient } from "~/lib/auth/client";
 import { models } from "~/lib/models";
 
 export function ChatView() {
-	const { data: session } = authClient.useSession();
-	const params = useParams({ strict: false }) as { chatId?: string };
-	const chatId = params?.chatId;
-	const chatsList = useChatsList();
-	const {
-		messages,
-		status,
-		append,
-		regenerate,
-		stop,
-		setSelectedModelId,
-		isLoadingMessages,
-	} = useChat(chatId);
+  const { data: session } = authClient.useSession();
+  const params = useParams({ strict: false }) as { chatId?: string };
+  const chatId = params?.chatId;
+  const chatsList = useChatsList();
+  const {
+    messages,
+    status,
+    append,
+    regenerate,
+    stop,
+    setSelectedModelId,
+    isLoadingMessages,
+  } = useChat(chatId);
 
-	const { messagesContainerRef, bottomRef, showScrollButton, scrollToBottom } =
-		useChatScroll();
+  const { messagesContainerRef, bottomRef, showScrollButton, scrollToBottom } =
+    useChatScroll();
 
-	useEffect(() => {
-		if (!chatId || !chatsList.data) return;
-		const chat = (
-			chatsList.data as Array<{ _id: string; model?: string }>
-		).find((c) => c._id === chatId);
-		if (chat?.model) {
-			const model = models.find((m) => m.modelId === chat.model);
-			if (model) {
-				setSelectedModelId((prev) => (prev === model.id ? prev : model.id));
-			}
-		}
-	}, [chatId, chatsList.data, setSelectedModelId]);
+  useEffect(() => {
+    if (!chatId || !chatsList.data) return;
+    const chat = (
+      chatsList.data as Array<{ _id: string; model?: string }>
+    ).find((c) => c._id === chatId);
+    if (chat?.model) {
+      const model = models.find((m) => m.modelId === chat.model);
+      if (model) {
+        setSelectedModelId((prev) => (prev === model.id ? prev : model.id));
+      }
+    }
+  }, [chatId, chatsList.data, setSelectedModelId]);
 
-	useEffect(() => {
-		if (messages.length > 0 && messagesContainerRef.current) {
-			messagesContainerRef.current.scrollTop =
-				messagesContainerRef.current.scrollHeight;
-		}
-	}, [messages.length, messagesContainerRef]);
+  useEffect(() => {
+    if (messages.length > 0 && messagesContainerRef.current) {
+      messagesContainerRef.current.scrollTop =
+        messagesContainerRef.current.scrollHeight;
+    }
+  }, [messages.length, messagesContainerRef]);
 
-	useFirstMessage({
-		chatId,
-		sessionToken: session?.session.token,
-		append,
-	});
+  useFirstMessage({
+    chatId,
+    sessionToken: session?.session.token,
+    append,
+  });
 
-	const isEmpty = !chatId || (messages.length === 0 && !isLoadingMessages);
+  const isEmpty = !chatId || (messages.length === 0 && !isLoadingMessages);
 
-	return (
-		<div className="relative h-screen bg-background">
-			<div
-				ref={messagesContainerRef}
-				className="scrollbar scrollbar-thumb-border scrollbar-track-transparent hover:scrollbar-thumb-border/80 scrollbar-w-2 absolute inset-0 ml-4 overflow-y-auto p-4 pb-32"
-			>
-				{isEmpty ? (
-					<div className="flex h-full items-center justify-center text-foreground">
-						<h1 className="text-2xl">Where should we begin?</h1>
-					</div>
-				) : (
-					<div className="mx-auto max-w-[752px] space-y-3 pt-5">
-						<AnimatePresence initial={false}>
-							{messages.map((m, index) => {
-								const handleMessageEdit = () => {
-									// Only regenerate if this is a user message
-									if (m.role === "user") {
-										// Trigger AI regeneration from the edited message
-										regenerate(m._id);
-									}
-								};
+  return (
+    <div className="relative h-screen bg-background">
+      <div
+        ref={messagesContainerRef}
+        className="scrollbar scrollbar-thumb-border scrollbar-track-transparent hover:scrollbar-thumb-border/80 scrollbar-w-2 absolute inset-0 ml-4 overflow-y-auto p-4 pb-32"
+      >
+        {isEmpty ? (
+          <div className="flex h-full items-center justify-center text-foreground">
+            <h1 className="text-2xl">Where should we begin?</h1>
+          </div>
+        ) : (
+          <div className="mx-auto max-w-[752px] space-y-3 pt-5">
+            <AnimatePresence initial={false}>
+              {messages.map((m, index) => {
+                const handleMessageEdit = () => {
+                  // Only regenerate if this is a user message
+                  if (m.role === "user") {
+                    // Trigger AI regeneration from the edited message
+                    regenerate(m._id);
+                  }
+                };
 
-								if (
-									status === ChatStatus.STREAMING &&
-									index === messages.length - 1 &&
-									m.status !== MessageStatus.COMPLETED
-								)
-									return (
-										<MessageErrorBoundary key={m._id}>
-											<Message
-												data={m}
-												user={session?.user}
-												onMessageEdit={handleMessageEdit}
-											/>
-										</MessageErrorBoundary>
-									);
+                if (
+                  status === ChatStatus.STREAMING &&
+                  index === messages.length - 1 &&
+                  m.status !== MessageStatus.COMPLETED
+                )
+                  return (
+                    <MessageErrorBoundary key={m._id}>
+                      <Message
+                        data={m}
+                        user={session?.user}
+                        onMessageEdit={handleMessageEdit}
+                      />
+                    </MessageErrorBoundary>
+                  );
 
-								return (
-									<MessageErrorBoundary key={m._id}>
-										<MemoizedMessage
-											data={m}
-											user={session?.user}
-											onMessageEdit={handleMessageEdit}
-										/>
-									</MessageErrorBoundary>
-								);
-							})}
-						</AnimatePresence>
-						<div ref={bottomRef} />
-					</div>
-				)}
-			</div>
+                return (
+                  <MessageErrorBoundary key={m._id}>
+                    <MemoizedMessage
+                      data={m}
+                      user={session?.user}
+                      onMessageEdit={handleMessageEdit}
+                    />
+                  </MessageErrorBoundary>
+                );
+              })}
+            </AnimatePresence>
+            <div ref={bottomRef} />
+          </div>
+        )}
+      </div>
 
-			<div className="absolute right-0 bottom-0 left-0 z-10">
-				<div className="relative bg-gradient-to-t from-background via-background to-transparent px-4 pt-8 pb-4">
-					<div className="-top-12 -translate-x-1/2 absolute left-1/2 z-20 transform">
-						<Button
-							variant="secondary"
-							size="icon"
-							className={`transition-all duration-300 ${showScrollButton ? "opacity-100" : "pointer-events-none opacity-0"} shadow-lg hover:bg-primary hover:text-primary-foreground`}
-							onClick={() => scrollToBottom()}
-						>
-							<ArrowDown className="size-4" />
-						</Button>
-					</div>
-					<ChatErrorBoundary>
-						<ChatInput
-							chatId={chatId}
-							sessionToken={session?.session.token ?? "skip"}
-							disabled={status === ChatStatus.STREAMING}
-							addUserMessage={(message, attachments) =>
-								append({ content: message, attachments })
-							}
-							onStop={stop}
-						/>
-					</ChatErrorBoundary>
-				</div>
-			</div>
-		</div>
-	);
+      <div className="absolute right-0 bottom-0 left-0 z-10">
+        <div className="relative bg-gradient-to-t from-background via-background to-transparent px-4 pt-8 pb-4">
+          <div className="-top-12 -translate-x-1/2 absolute left-1/2 z-20 transform">
+            <Button
+              variant="secondary"
+              size="icon"
+              className={`transition-all duration-300 ${showScrollButton ? "opacity-100" : "pointer-events-none opacity-0"} shadow-lg hover:bg-primary hover:text-primary-foreground`}
+              onClick={() => scrollToBottom()}
+            >
+              <ArrowDown className="size-4" />
+            </Button>
+          </div>
+          <ChatErrorBoundary>
+            <ChatInput
+              chatId={chatId}
+              sessionToken={session?.session.token ?? "skip"}
+              disabled={status === ChatStatus.STREAMING}
+              addUserMessage={(message, attachments) =>
+                append({ content: message, attachments })
+              }
+              onStop={stop}
+            />
+          </ChatErrorBoundary>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/components/chat/message.tsx
+++ b/apps/web/src/components/chat/message.tsx
@@ -181,7 +181,7 @@ function MessageAttachments({ messageId }: { messageId: string }) {
 interface MessageProps {
   readonly data: ChatMessage;
   readonly user?: User;
-  readonly onMessageEdit?: () => void;
+  readonly onMessageEdit?: (editedContent: string) => void;
 }
 
 export const Message = function Message({
@@ -244,9 +244,9 @@ export const Message = function Message({
 
       // Wait a bit for Convex to propagate the changes
       setTimeout(() => {
-        // Trigger AI regeneration if callback is provided
+        // Trigger AI regeneration if callback is provided with the edited content
         if (onMessageEdit) {
-          onMessageEdit();
+          onMessageEdit(editText.trim());
         }
       }, 200);
     } catch (error) {

--- a/apps/web/src/components/chat/message.tsx
+++ b/apps/web/src/components/chat/message.tsx
@@ -1,9 +1,9 @@
 import { Icon } from "@iconify/react";
 import type { User } from "better-auth";
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { marked } from "marked";
 import { motion } from "motion/react";
-import { memo, useMemo, useState } from "react";
+import { memo, useMemo, useRef, useState } from "react";
 import { ProfileAvatar } from "~/components/auth/profile-avatar";
 import { AttachmentList } from "~/components/chat/attachment-preview";
 import { TokenBlock } from "~/components/chat/blocks";
@@ -181,10 +181,21 @@ function MessageAttachments({ messageId }: { messageId: string }) {
 interface MessageProps {
   readonly data: ChatMessage;
   readonly user?: User;
+  readonly onMessageEdit?: () => void;
 }
 
-export const Message = function Message({ data, user }: MessageProps) {
+export const Message = function Message({
+  data,
+  user,
+  onMessageEdit,
+}: MessageProps) {
   const { isCopied, copy } = useClipboardCopy();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState(data.content);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { data: session } = authClient.useSession();
+  const editMessage = useMutation(api.functions.message.editUserMessage);
+
   const contentTokens = useMemo(
     () => marked.lexer(data.content),
     [data.content],
@@ -195,6 +206,49 @@ export const Message = function Message({ data, user }: MessageProps) {
   const name = user?.name ?? "Unknown";
   const date = formatDate(new Date(data?._creationTime));
   const error = "error" in data && data.error ? data.error : null;
+
+  const handleEdit = () => {
+    setIsEditing(true);
+    setEditText(data.content);
+    setTimeout(() => {
+      if (textareaRef.current) {
+        textareaRef.current.focus();
+        textareaRef.current.setSelectionRange(
+          textareaRef.current.value.length,
+          textareaRef.current.value.length,
+        );
+      }
+    }, 0);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditText(data.content);
+  };
+
+  const handleSave = async () => {
+    if (!session?.session.token || editText.trim() === data.content.trim()) {
+      handleCancel();
+      return;
+    }
+
+    try {
+      await editMessage({
+        messageId: data._id,
+        content: editText.trim(),
+        sessionToken: session.session.token,
+      });
+      setIsEditing(false);
+
+      // Trigger AI regeneration if callback is provided
+      if (onMessageEdit) {
+        onMessageEdit();
+      }
+    } catch (error) {
+      console.error("Failed to edit message:", error);
+      // Optionally handle error UI here
+    }
+  };
 
   return (
     <div className="group flex max-w-full flex-col gap-y-2">
@@ -226,11 +280,49 @@ export const Message = function Message({ data, user }: MessageProps) {
               {isUser && <div className="text-gray-500 text-xs">{name}</div>}
               {isUser && <div className="text-gray-500 text-xs">{date}</div>}
             </div>
-            <div className="min-w-0 whitespace-pre-wrap break-words">
-              {contentTokens.map((token, index) => (
-                <TokenBlock key={getTokenKey(token, index)} token={token} />
-              ))}
-            </div>
+            {isEditing ? (
+              <div className="w-full space-y-2">
+                <textarea
+                  ref={textareaRef}
+                  value={editText}
+                  onChange={(e) => setEditText(e.target.value)}
+                  className="min-h-[80px] w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                      e.preventDefault();
+                      handleSave();
+                    } else if (e.key === "Escape") {
+                      e.preventDefault();
+                      handleCancel();
+                    }
+                  }}
+                />
+                <div className="flex justify-end gap-x-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleCancel}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="sm"
+                    onClick={handleSave}
+                  >
+                    Save
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="min-w-0 whitespace-pre-wrap break-words">
+                {contentTokens.map((token, index) => (
+                  <TokenBlock key={getTokenKey(token, index)} token={token} />
+                ))}
+              </div>
+            )}
             <MessageAttachments messageId={data._id} />
           </div>
         </div>
@@ -240,6 +332,20 @@ export const Message = function Message({ data, user }: MessageProps) {
           {error}
         </div>
         <div className="flex items-center gap-x-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+          {isUser && !isEditing && (
+            <Button
+              type="button"
+              onMouseDown={handleEdit}
+              variant="ghost"
+              size="icon"
+              className="h-4 w-4"
+            >
+              <Icon
+                icon="lucide:pencil"
+                className="bg-transparent text-gray-500"
+              />
+            </Button>
+          )}
           <Button
             type="button"
             onMouseDown={() => copy(data.content)}

--- a/apps/web/src/components/chat/message.tsx
+++ b/apps/web/src/components/chat/message.tsx
@@ -233,20 +233,25 @@ export const Message = function Message({
     }
 
     try {
+      // First edit the message and wait for it to complete
       await editMessage({
         messageId: data._id,
         content: editText.trim(),
         sessionToken: session.session.token,
       });
+
       setIsEditing(false);
 
-      // Trigger AI regeneration if callback is provided
-      if (onMessageEdit) {
-        onMessageEdit();
-      }
+      // Wait a bit for Convex to propagate the changes
+      setTimeout(() => {
+        // Trigger AI regeneration if callback is provided
+        if (onMessageEdit) {
+          onMessageEdit();
+        }
+      }, 200);
     } catch (error) {
       console.error("Failed to edit message:", error);
-      // Optionally handle error UI here
+      setIsEditing(false);
     }
   };
 

--- a/apps/web/src/hooks/use-chat.ts
+++ b/apps/web/src/hooks/use-chat.ts
@@ -1,16 +1,16 @@
 import { useMutation, useQuery } from "convex/react";
 import { useCallback, useEffect } from "react";
 import {
-  type ChatMessage,
-  ChatStatus,
-  type MessageReasoning,
-  MessageStatus,
+	type ChatMessage,
+	ChatStatus,
+	type MessageReasoning,
+	MessageStatus,
 } from "~/components/chat/types";
 import { useChatSettings } from "~/hooks/use-chat-settings";
 import { useChatStore, useChatStoreSubscription } from "~/hooks/use-chat-store";
 import {
-  createTempMessages,
-  shouldEnablePolling,
+	createTempMessages,
+	shouldEnablePolling,
 } from "~/hooks/use-chat-utils";
 import { usePolling } from "~/hooks/use-polling";
 import { processDataStream } from "~/lib/ai/process-chat-response";
@@ -23,427 +23,428 @@ import { logger } from "~/lib/logger";
 import { getModelById } from "~/lib/models";
 
 export function useChat(chatId: string | undefined) {
-  const { data: session } = authClient.useSession();
-  const sessionToken = session?.session.token;
+	const { data: session } = authClient.useSession();
+	const sessionToken = session?.session.token;
 
-  const settings = useChatSettings();
-  const store = useChatStore(chatId);
+	const settings = useChatSettings();
+	const store = useChatStore(chatId);
 
-  const messages = useChatStoreSubscription(chatId, (state) => state.messages);
-  const status = useChatStoreSubscription(chatId, (state) => state.status);
-  const abortController = useChatStoreSubscription(
-    chatId,
-    (state) => state.abortController,
-  );
-  const currentChatId = useChatStoreSubscription(
-    chatId,
-    (state) => state.currentChatId,
-  );
-  const isInitialLoad = useChatStoreSubscription(
-    chatId,
-    (state) => state.isInitialLoad,
-  );
-  const pollEnabled = useChatStoreSubscription(
-    chatId,
-    (state) => state.pollEnabled,
-  );
+	const messages = useChatStoreSubscription(chatId, (state) => state.messages);
+	const status = useChatStoreSubscription(chatId, (state) => state.status);
+	const abortController = useChatStoreSubscription(
+		chatId,
+		(state) => state.abortController,
+	);
+	const currentChatId = useChatStoreSubscription(
+		chatId,
+		(state) => state.currentChatId,
+	);
+	const isInitialLoad = useChatStoreSubscription(
+		chatId,
+		(state) => state.isInitialLoad,
+	);
+	const pollEnabled = useChatStoreSubscription(
+		chatId,
+		(state) => state.pollEnabled,
+	);
 
-  const updateAiMessage = useMutation(api.functions.message.updateAiMessage);
-  const getChatMessages = useQuery(
-    api.functions.chat.getChatMessages,
-    isConvexId<"chat">(chatId) && sessionToken
-      ? { chatId: chatId, sessionToken }
-      : "skip",
-  );
+	const updateAiMessage = useMutation(api.functions.message.updateAiMessage);
+	const getChatMessages = useQuery(
+		api.functions.chat.getChatMessages,
+		isConvexId<"chat">(chatId) && sessionToken
+			? { chatId: chatId, sessionToken }
+			: "skip",
+	);
 
-  usePolling({
-    enabled: pollEnabled,
-    onPoll: () => {
-      const lastMessage = messages[messages.length - 1];
-      logger.debug(
-        `Polling for message updates in chat ${chatId} (${messages.length} messages, last status: ${lastMessage?.status || "none"})`,
-      );
-    },
-  });
+	usePolling({
+		enabled: pollEnabled,
+		onPoll: () => {
+			const lastMessage = messages[messages.length - 1];
+			logger.debug(
+				`Polling for message updates in chat ${chatId} (${messages.length} messages, last status: ${lastMessage?.status || "none"})`,
+			);
+		},
+	});
 
-  useEffect(() => {
-    if (chatId !== currentChatId) {
-      store.resetChat(chatId);
-    }
-  }, [chatId, currentChatId, store.resetChat]);
+	useEffect(() => {
+		if (chatId !== currentChatId) {
+			store.resetChat(chatId);
+		}
+	}, [chatId, currentChatId, store.resetChat]);
 
-  useEffect(() => {
-    if (!getChatMessages || chatId !== currentChatId || !sessionToken) {
-      return;
-    }
+	useEffect(() => {
+		if (!getChatMessages || chatId !== currentChatId || !sessionToken) {
+			return;
+		}
 
-    store.setMessages(getChatMessages);
+		store.setMessages(getChatMessages);
 
-    if (isInitialLoad) {
-      store.setInitialLoad(false);
-      if (shouldEnablePolling(getChatMessages)) {
-        store.setPollEnabled(true);
-      }
-    } else if (pollEnabled && !shouldEnablePolling(getChatMessages)) {
-      store.setPollEnabled(false);
-    }
-  }, [
-    getChatMessages,
-    chatId,
-    currentChatId,
-    sessionToken,
-    isInitialLoad,
-    pollEnabled,
-    store.setMessages,
-    store.setInitialLoad,
-    store.setPollEnabled,
-  ]);
+		if (isInitialLoad) {
+			store.setInitialLoad(false);
+			if (shouldEnablePolling(getChatMessages)) {
+				store.setPollEnabled(true);
+			}
+		} else if (pollEnabled && !shouldEnablePolling(getChatMessages)) {
+			store.setPollEnabled(false);
+		}
+	}, [
+		getChatMessages,
+		chatId,
+		currentChatId,
+		sessionToken,
+		isInitialLoad,
+		pollEnabled,
+		store.setMessages,
+		store.setInitialLoad,
+		store.setPollEnabled,
+	]);
 
-  const append = useCallback(
-    async ({
-      content,
-      attachments,
-    }: { content: string; attachments?: SerializedFile[] }) => {
-      if (!isConvexId<"chat">(chatId)) {
-        return;
-      }
+	const append = useCallback(
+		async ({
+			content,
+			attachments,
+		}: { content: string; attachments?: SerializedFile[] }) => {
+			if (!isConvexId<"chat">(chatId)) {
+				return;
+			}
 
-      const controller = new AbortController();
-      store.setAbortController(controller);
+			const controller = new AbortController();
+			store.setAbortController(controller);
 
-      const selectedModel = getModelById(settings.selectedModelId);
-      const [tempUserMessage, tempAiMessage] = createTempMessages(
-        chatId,
-        content,
-        selectedModel || null,
-      );
+			const selectedModel = getModelById(settings.selectedModelId);
+			const [tempUserMessage, tempAiMessage] = createTempMessages(
+				chatId,
+				content,
+				selectedModel || null,
+			);
 
-      const attachmentCount = attachments?.length ?? 0;
-      logger.info(
-        `Sending message to chat ${chatId} (model: ${selectedModel?.name}, search: ${settings.searchEnabled}, attachments: ${attachmentCount})`,
-      );
+			const attachmentCount = attachments?.length ?? 0;
+			logger.info(
+				`Sending message to chat ${chatId} (model: ${selectedModel?.name}, search: ${settings.searchEnabled}, attachments: ${attachmentCount})`,
+			);
 
-      store.addMessages([
-        tempUserMessage as ChatMessage,
-        tempAiMessage as ChatMessage,
-      ]);
+			store.addMessages([
+				tempUserMessage as ChatMessage,
+				tempAiMessage as ChatMessage,
+			]);
 
-      try {
-        const response = await fetch("/api/chat", {
-          method: "POST",
-          signal: controller.signal,
-          body: JSON.stringify({
-            chatId,
-            modelId: settings.selectedModelId,
-            messages: [...messages, { role: "user", content }],
-            search: settings.searchEnabled,
-            reasoningEffort:
-              selectedModel && !!selectedModel.reasoningEffort
-                ? settings.reasoningEffort
-                : undefined,
-            attachments,
-          }),
-        });
+			try {
+				const response = await fetch("/api/chat", {
+					method: "POST",
+					signal: controller.signal,
+					body: JSON.stringify({
+						chatId,
+						modelId: settings.selectedModelId,
+						messages: [...messages, { role: "user", content }],
+						search: settings.searchEnabled,
+						reasoningEffort:
+							selectedModel && !!selectedModel.reasoningEffort
+								? settings.reasoningEffort
+								: undefined,
+						attachments,
+					}),
+				});
 
-        if (!response.ok || !response.body) {
-          throw new Error("Failed to append message");
-        }
+				if (!response.ok || !response.body) {
+					throw new Error("Failed to append message");
+				}
 
-        settings.resetSearchToggle();
+				settings.resetSearchToggle();
 
-        let contentBuffer = "";
-        const reasoningBuffer: MessageReasoning = {
-          text: "",
-          details: [],
-          duration: 0,
-          reasoningEffort: settings.reasoningEffort,
-        };
-        let lastReasoningPart = "";
+				let contentBuffer = "";
+				const reasoningBuffer: MessageReasoning = {
+					text: "",
+					details: [],
+					duration: 0,
+					reasoningEffort: settings.reasoningEffort,
+				};
+				let lastReasoningPart = "";
 
-        await processDataStream({
-          stream: response.body,
-          onTextPart(value) {
-            if (chatId === currentChatId) {
-              store.setStatus(ChatStatus.STREAMING);
-              contentBuffer += value;
-              store.updateLastMessage({
-                content: contentBuffer,
-                status: MessageStatus.GENERATING,
-              });
-            }
-          },
-          onReasoningPart(value) {
-            if (chatId === currentChatId) {
-              store.setStatus(ChatStatus.STREAMING);
-              if (value !== lastReasoningPart) {
-                reasoningBuffer.text += value;
-                lastReasoningPart = value;
-              }
+				await processDataStream({
+					stream: response.body,
+					onTextPart(value) {
+						if (chatId === currentChatId) {
+							store.setStatus(ChatStatus.STREAMING);
+							contentBuffer += value;
+							store.updateLastMessage({
+								content: contentBuffer,
+								status: MessageStatus.GENERATING,
+							});
+						}
+					},
+					onReasoningPart(value) {
+						if (chatId === currentChatId) {
+							store.setStatus(ChatStatus.STREAMING);
+							if (value !== lastReasoningPart) {
+								reasoningBuffer.text += value;
+								lastReasoningPart = value;
+							}
 
-              const steps = splitReasoningSteps(reasoningBuffer.text).map(
-                (step) => ({ text: step }),
-              );
-              const completedReasoning =
-                reasoningBuffer.text.length > 0
-                  ? {
-                      text: reasoningBuffer.text,
-                      details: steps,
-                      duration: reasoningBuffer.duration,
-                      reasoningEffort: settings.reasoningEffort,
-                    }
-                  : undefined;
+							const steps = splitReasoningSteps(reasoningBuffer.text).map(
+								(step) => ({ text: step }),
+							);
+							const completedReasoning =
+								reasoningBuffer.text.length > 0
+									? {
+											text: reasoningBuffer.text,
+											details: steps,
+											duration: reasoningBuffer.duration,
+											reasoningEffort: settings.reasoningEffort,
+										}
+									: undefined;
 
-              store.updateLastMessage({
-                content: contentBuffer,
-                reasoning: completedReasoning,
-                status: MessageStatus.REASONING,
-              });
-            }
-          },
-          onFinishMessagePart() {
-            if (chatId === currentChatId) {
-              const steps = splitReasoningSteps(reasoningBuffer.text).map(
-                (step) => ({ text: step }),
-              );
-              const completedReasoning =
-                reasoningBuffer.text.length > 0
-                  ? {
-                      text: reasoningBuffer.text,
-                      details: steps,
-                      duration: reasoningBuffer.duration,
-                      reasoningEffort: settings.reasoningEffort,
-                    }
-                  : undefined;
+							store.updateLastMessage({
+								content: contentBuffer,
+								reasoning: completedReasoning,
+								status: MessageStatus.REASONING,
+							});
+						}
+					},
+					onFinishMessagePart() {
+						if (chatId === currentChatId) {
+							const steps = splitReasoningSteps(reasoningBuffer.text).map(
+								(step) => ({ text: step }),
+							);
+							const completedReasoning =
+								reasoningBuffer.text.length > 0
+									? {
+											text: reasoningBuffer.text,
+											details: steps,
+											duration: reasoningBuffer.duration,
+											reasoningEffort: settings.reasoningEffort,
+										}
+									: undefined;
 
-              store.updateLastMessage({
-                content: contentBuffer,
-                reasoning: completedReasoning,
-                status: MessageStatus.COMPLETED,
-              });
-            }
-          },
-        });
-      } catch (error) {
-        if ((error as Error).name === "AbortError") {
-          if (chatId === currentChatId) {
-            store.updateLastMessage({ status: MessageStatus.ABORTED });
-          }
-        }
-      } finally {
-        if (chatId === currentChatId) {
-          store.setStatus(ChatStatus.IDLE);
-        }
-        store.setAbortController(null);
-      }
-    },
-    [
-      chatId,
-      currentChatId,
-      messages,
-      settings.selectedModelId,
-      settings.searchEnabled,
-      settings.resetSearchToggle,
-      settings.reasoningEffort,
-      store.addMessages,
-      store.setStatus,
-      store.setAbortController,
-      store.updateLastMessage,
-    ],
-  );
+							store.updateLastMessage({
+								content: contentBuffer,
+								reasoning: completedReasoning,
+								status: MessageStatus.COMPLETED,
+							});
+						}
+					},
+				});
+			} catch (error) {
+				if ((error as Error).name === "AbortError") {
+					if (chatId === currentChatId) {
+						store.updateLastMessage({ status: MessageStatus.ABORTED });
+					}
+				}
+			} finally {
+				if (chatId === currentChatId) {
+					store.setStatus(ChatStatus.IDLE);
+				}
+				store.setAbortController(null);
+			}
+		},
+		[
+			chatId,
+			currentChatId,
+			messages,
+			settings.selectedModelId,
+			settings.searchEnabled,
+			settings.resetSearchToggle,
+			settings.reasoningEffort,
+			store.addMessages,
+			store.setStatus,
+			store.setAbortController,
+			store.updateLastMessage,
+		],
+	);
 
-  const regenerate = useCallback(
-    async (upToMessageId: string, editedContent?: string) => {
-      if (!isConvexId<"chat">(chatId) || !sessionToken) {
-        return;
-      }
+	const regenerate = useCallback(
+		async (upToMessageId: string, editedContent?: string) => {
+			if (!isConvexId<"chat">(chatId) || !sessionToken) {
+				return;
+			}
 
-      // Find the index of the message we're regenerating from
-      const messageIndex = messages.findIndex((m) => m._id === upToMessageId);
-      if (messageIndex === -1) return;
+			// Find the index of the message we're regenerating from
+			const messageIndex = messages.findIndex((m) => m._id === upToMessageId);
+			if (messageIndex === -1) return;
 
-      // Get all messages up to and including the edited message
-      // If editedContent is provided, update the last user message with it
-      const messagesForRegeneration = messages
-        .slice(0, messageIndex + 1)
-        .map((msg, idx) => {
-          if (
-            idx === messageIndex &&
-            editedContent !== undefined &&
-            msg.role === "user"
-          ) {
-            return { ...msg, content: editedContent };
-          }
-          return msg;
-        });
+			// Get all messages up to and including the edited message
+			// If editedContent is provided, update the last user message with it
+			const messagesForRegeneration = messages
+				.slice(0, messageIndex + 1)
+				.map((msg, idx) => {
+					if (
+						idx === messageIndex &&
+						editedContent !== undefined &&
+						msg.role === "user"
+					) {
+						return { ...msg, content: editedContent };
+					}
+					return msg;
+				});
 
-      const controller = new AbortController();
-      store.setAbortController(controller);
+			const controller = new AbortController();
+			store.setAbortController(controller);
 
-      const selectedModel = getModelById(settings.selectedModelId);
-      const tempAiMessage = createTempMessages(
-        chatId,
-        "",
-        selectedModel || null,
-      )[1];
+			const selectedModel = getModelById(settings.selectedModelId);
+			const tempAiMessage = createTempMessages(
+				chatId,
+				"",
+				selectedModel || null,
+			)[1];
 
-      logger.info(
-        `Regenerating AI response after message edit in chat ${chatId} (model: ${selectedModel?.name})`,
-      );
+			logger.info(
+				`Regenerating AI response after message edit in chat ${chatId} (model: ${selectedModel?.name})`,
+			);
 
-      // Enable polling to ensure we get the latest messages
-      store.setPollEnabled(true);
+			// Enable polling to ensure we get the latest messages
+			store.setPollEnabled(true);
 
-      // Only add the AI message to the store
-      store.addMessages([tempAiMessage as ChatMessage]);
+			// Only add the AI message to the store
+			store.addMessages([tempAiMessage as ChatMessage]);
 
-      try {
-        const response = await fetch("/api/chat", {
-          method: "POST",
-          signal: controller.signal,
-          body: JSON.stringify({
-            chatId,
-            modelId: settings.selectedModelId,
-            messages: messagesForRegeneration.map((m) => ({
-              role: m.role,
-              content: m.content,
-            })),
-            search: settings.searchEnabled,
-            reasoningEffort:
-              selectedModel && !!selectedModel.reasoningEffort
-                ? settings.reasoningEffort
-                : undefined,
-          }),
-        });
+			try {
+				const response = await fetch("/api/chat", {
+					method: "POST",
+					signal: controller.signal,
+					body: JSON.stringify({
+						chatId,
+						modelId: settings.selectedModelId,
+						messages: messagesForRegeneration.map((m) => ({
+							role: m.role,
+							content: m.content,
+						})),
+						search: settings.searchEnabled,
+						reasoningEffort:
+							selectedModel && !!selectedModel.reasoningEffort
+								? settings.reasoningEffort
+								: undefined,
+						isRegeneration: true, // Flag to prevent creating a new user message
+					}),
+				});
 
-        if (!response.ok || !response.body) {
-          throw new Error("Failed to regenerate response");
-        }
+				if (!response.ok || !response.body) {
+					throw new Error("Failed to regenerate response");
+				}
 
-        settings.resetSearchToggle();
+				settings.resetSearchToggle();
 
-        let contentBuffer = "";
-        const reasoningBuffer: MessageReasoning = {
-          text: "",
-          details: [],
-          duration: 0,
-          reasoningEffort: settings.reasoningEffort,
-        };
-        let lastReasoningPart = "";
+				let contentBuffer = "";
+				const reasoningBuffer: MessageReasoning = {
+					text: "",
+					details: [],
+					duration: 0,
+					reasoningEffort: settings.reasoningEffort,
+				};
+				let lastReasoningPart = "";
 
-        await processDataStream({
-          stream: response.body,
-          onTextPart(value) {
-            if (chatId === currentChatId) {
-              store.setStatus(ChatStatus.STREAMING);
-              contentBuffer += value;
-              store.updateLastMessage({
-                content: contentBuffer,
-                status: MessageStatus.GENERATING,
-              });
-            }
-          },
-          onReasoningPart(value) {
-            if (chatId === currentChatId) {
-              store.setStatus(ChatStatus.STREAMING);
-              if (value !== lastReasoningPart) {
-                reasoningBuffer.text += value;
-                lastReasoningPart = value;
-              }
+				await processDataStream({
+					stream: response.body,
+					onTextPart(value) {
+						if (chatId === currentChatId) {
+							store.setStatus(ChatStatus.STREAMING);
+							contentBuffer += value;
+							store.updateLastMessage({
+								content: contentBuffer,
+								status: MessageStatus.GENERATING,
+							});
+						}
+					},
+					onReasoningPart(value) {
+						if (chatId === currentChatId) {
+							store.setStatus(ChatStatus.STREAMING);
+							if (value !== lastReasoningPart) {
+								reasoningBuffer.text += value;
+								lastReasoningPart = value;
+							}
 
-              const steps = splitReasoningSteps(reasoningBuffer.text).map(
-                (step) => ({ text: step }),
-              );
-              const completedReasoning =
-                reasoningBuffer.text.length > 0
-                  ? {
-                      text: reasoningBuffer.text,
-                      details: steps,
-                      duration: reasoningBuffer.duration,
-                      reasoningEffort: settings.reasoningEffort,
-                    }
-                  : undefined;
+							const steps = splitReasoningSteps(reasoningBuffer.text).map(
+								(step) => ({ text: step }),
+							);
+							const completedReasoning =
+								reasoningBuffer.text.length > 0
+									? {
+											text: reasoningBuffer.text,
+											details: steps,
+											duration: reasoningBuffer.duration,
+											reasoningEffort: settings.reasoningEffort,
+										}
+									: undefined;
 
-              store.updateLastMessage({
-                content: contentBuffer,
-                reasoning: completedReasoning,
-                status: MessageStatus.REASONING,
-              });
-            }
-          },
-          onFinishMessagePart() {
-            if (chatId === currentChatId) {
-              const steps = splitReasoningSteps(reasoningBuffer.text).map(
-                (step) => ({ text: step }),
-              );
-              const completedReasoning =
-                reasoningBuffer.text.length > 0
-                  ? {
-                      text: reasoningBuffer.text,
-                      details: steps,
-                      duration: reasoningBuffer.duration,
-                      reasoningEffort: settings.reasoningEffort,
-                    }
-                  : undefined;
+							store.updateLastMessage({
+								content: contentBuffer,
+								reasoning: completedReasoning,
+								status: MessageStatus.REASONING,
+							});
+						}
+					},
+					onFinishMessagePart() {
+						if (chatId === currentChatId) {
+							const steps = splitReasoningSteps(reasoningBuffer.text).map(
+								(step) => ({ text: step }),
+							);
+							const completedReasoning =
+								reasoningBuffer.text.length > 0
+									? {
+											text: reasoningBuffer.text,
+											details: steps,
+											duration: reasoningBuffer.duration,
+											reasoningEffort: settings.reasoningEffort,
+										}
+									: undefined;
 
-              store.updateLastMessage({
-                content: contentBuffer,
-                reasoning: completedReasoning,
-                status: MessageStatus.COMPLETED,
-              });
-            }
-          },
-        });
-      } catch (error) {
-        if ((error as Error).name === "AbortError") {
-          if (chatId === currentChatId) {
-            store.updateLastMessage({ status: MessageStatus.ABORTED });
-          }
-        }
-      } finally {
-        if (chatId === currentChatId) {
-          store.setStatus(ChatStatus.IDLE);
-        }
-        store.setAbortController(null);
-      }
-    },
-    [
-      chatId,
-      currentChatId,
-      messages,
-      sessionToken,
-      settings.selectedModelId,
-      settings.searchEnabled,
-      settings.resetSearchToggle,
-      settings.reasoningEffort,
-      store.addMessages,
-      store.setStatus,
-      store.setAbortController,
-      store.updateLastMessage,
-      store.setPollEnabled,
-    ],
-  );
+							store.updateLastMessage({
+								content: contentBuffer,
+								reasoning: completedReasoning,
+								status: MessageStatus.COMPLETED,
+							});
+						}
+					},
+				});
+			} catch (error) {
+				if ((error as Error).name === "AbortError") {
+					if (chatId === currentChatId) {
+						store.updateLastMessage({ status: MessageStatus.ABORTED });
+					}
+				}
+			} finally {
+				if (chatId === currentChatId) {
+					store.setStatus(ChatStatus.IDLE);
+				}
+				store.setAbortController(null);
+			}
+		},
+		[
+			chatId,
+			currentChatId,
+			messages,
+			sessionToken,
+			settings.selectedModelId,
+			settings.searchEnabled,
+			settings.resetSearchToggle,
+			settings.reasoningEffort,
+			store.addMessages,
+			store.setStatus,
+			store.setAbortController,
+			store.updateLastMessage,
+			store.setPollEnabled,
+		],
+	);
 
-  const stop = useCallback(() => {
-    if (abortController) {
-      updateAiMessage({
-        messageId: messages[messages.length - 1]._id,
-        status: MessageStatus.ABORTED,
-        sessionToken: sessionToken ?? "skip",
-      });
-      abortController.abort();
-    }
-  }, [abortController, messages, updateAiMessage, sessionToken]);
+	const stop = useCallback(() => {
+		if (abortController) {
+			updateAiMessage({
+				messageId: messages[messages.length - 1]._id,
+				status: MessageStatus.ABORTED,
+				sessionToken: sessionToken ?? "skip",
+			});
+			abortController.abort();
+		}
+	}, [abortController, messages, updateAiMessage, sessionToken]);
 
-  return {
-    messages,
-    isLoadingMessages: !getChatMessages || !sessionToken,
-    status,
-    append,
-    regenerate,
-    stop,
-    selectedModelId: settings.selectedModelId,
-    setSelectedModelId: settings.setSelectedModelId,
-    searchEnabled: settings.searchEnabled,
-    setSearchEnabled: settings.setSearchEnabled,
-  } as const;
+	return {
+		messages,
+		isLoadingMessages: !getChatMessages || !sessionToken,
+		status,
+		append,
+		regenerate,
+		stop,
+		selectedModelId: settings.selectedModelId,
+		setSelectedModelId: settings.setSelectedModelId,
+		searchEnabled: settings.searchEnabled,
+		setSearchEnabled: settings.setSearchEnabled,
+	} as const;
 }

--- a/apps/web/src/hooks/use-chat.ts
+++ b/apps/web/src/hooks/use-chat.ts
@@ -1,16 +1,16 @@
 import { useMutation, useQuery } from "convex/react";
 import { useCallback, useEffect } from "react";
 import {
-	type ChatMessage,
-	ChatStatus,
-	type MessageReasoning,
-	MessageStatus,
+  type ChatMessage,
+  ChatStatus,
+  type MessageReasoning,
+  MessageStatus,
 } from "~/components/chat/types";
 import { useChatSettings } from "~/hooks/use-chat-settings";
 import { useChatStore, useChatStoreSubscription } from "~/hooks/use-chat-store";
 import {
-	createTempMessages,
-	shouldEnablePolling,
+  createTempMessages,
+  shouldEnablePolling,
 } from "~/hooks/use-chat-utils";
 import { usePolling } from "~/hooks/use-polling";
 import { processDataStream } from "~/lib/ai/process-chat-response";
@@ -23,411 +23,415 @@ import { logger } from "~/lib/logger";
 import { getModelById } from "~/lib/models";
 
 export function useChat(chatId: string | undefined) {
-	const { data: session } = authClient.useSession();
-	const sessionToken = session?.session.token;
+  const { data: session } = authClient.useSession();
+  const sessionToken = session?.session.token;
 
-	const settings = useChatSettings();
-	const store = useChatStore(chatId);
+  const settings = useChatSettings();
+  const store = useChatStore(chatId);
 
-	const messages = useChatStoreSubscription(chatId, (state) => state.messages);
-	const status = useChatStoreSubscription(chatId, (state) => state.status);
-	const abortController = useChatStoreSubscription(
-		chatId,
-		(state) => state.abortController,
-	);
-	const currentChatId = useChatStoreSubscription(
-		chatId,
-		(state) => state.currentChatId,
-	);
-	const isInitialLoad = useChatStoreSubscription(
-		chatId,
-		(state) => state.isInitialLoad,
-	);
-	const pollEnabled = useChatStoreSubscription(
-		chatId,
-		(state) => state.pollEnabled,
-	);
+  const messages = useChatStoreSubscription(chatId, (state) => state.messages);
+  const status = useChatStoreSubscription(chatId, (state) => state.status);
+  const abortController = useChatStoreSubscription(
+    chatId,
+    (state) => state.abortController,
+  );
+  const currentChatId = useChatStoreSubscription(
+    chatId,
+    (state) => state.currentChatId,
+  );
+  const isInitialLoad = useChatStoreSubscription(
+    chatId,
+    (state) => state.isInitialLoad,
+  );
+  const pollEnabled = useChatStoreSubscription(
+    chatId,
+    (state) => state.pollEnabled,
+  );
 
-	const updateAiMessage = useMutation(api.functions.message.updateAiMessage);
-	const getChatMessages = useQuery(
-		api.functions.chat.getChatMessages,
-		isConvexId<"chat">(chatId) && sessionToken && (isInitialLoad || pollEnabled)
-			? { chatId: chatId, sessionToken }
-			: "skip",
-	);
+  const updateAiMessage = useMutation(api.functions.message.updateAiMessage);
+  const getChatMessages = useQuery(
+    api.functions.chat.getChatMessages,
+    isConvexId<"chat">(chatId) && sessionToken
+      ? { chatId: chatId, sessionToken }
+      : "skip",
+  );
 
-	usePolling({
-		enabled: pollEnabled,
-		onPoll: () => {
-			const lastMessage = messages[messages.length - 1];
-			logger.debug(
-				`Polling for message updates in chat ${chatId} (${messages.length} messages, last status: ${lastMessage?.status || "none"})`,
-			);
-		},
-	});
+  usePolling({
+    enabled: pollEnabled,
+    onPoll: () => {
+      const lastMessage = messages[messages.length - 1];
+      logger.debug(
+        `Polling for message updates in chat ${chatId} (${messages.length} messages, last status: ${lastMessage?.status || "none"})`,
+      );
+    },
+  });
 
-	useEffect(() => {
-		if (chatId !== currentChatId) {
-			store.resetChat(chatId);
-		}
-	}, [chatId, currentChatId, store.resetChat]);
+  useEffect(() => {
+    if (chatId !== currentChatId) {
+      store.resetChat(chatId);
+    }
+  }, [chatId, currentChatId, store.resetChat]);
 
-	useEffect(() => {
-		if (!getChatMessages || chatId !== currentChatId || !sessionToken) {
-			return;
-		}
+  useEffect(() => {
+    if (!getChatMessages || chatId !== currentChatId || !sessionToken) {
+      return;
+    }
 
-		store.setMessages(getChatMessages);
+    store.setMessages(getChatMessages);
 
-		if (isInitialLoad) {
-			store.setInitialLoad(false);
-			if (shouldEnablePolling(getChatMessages)) {
-				store.setPollEnabled(true);
-			}
-		} else if (pollEnabled && !shouldEnablePolling(getChatMessages)) {
-			store.setPollEnabled(false);
-		}
-	}, [
-		getChatMessages,
-		chatId,
-		currentChatId,
-		sessionToken,
-		isInitialLoad,
-		pollEnabled,
-		store.setMessages,
-		store.setInitialLoad,
-		store.setPollEnabled,
-	]);
+    if (isInitialLoad) {
+      store.setInitialLoad(false);
+      if (shouldEnablePolling(getChatMessages)) {
+        store.setPollEnabled(true);
+      }
+    } else if (pollEnabled && !shouldEnablePolling(getChatMessages)) {
+      store.setPollEnabled(false);
+    }
+  }, [
+    getChatMessages,
+    chatId,
+    currentChatId,
+    sessionToken,
+    isInitialLoad,
+    pollEnabled,
+    store.setMessages,
+    store.setInitialLoad,
+    store.setPollEnabled,
+  ]);
 
-	const append = useCallback(
-		async ({
-			content,
-			attachments,
-		}: { content: string; attachments?: SerializedFile[] }) => {
-			if (!isConvexId<"chat">(chatId)) {
-				return;
-			}
+  const append = useCallback(
+    async ({
+      content,
+      attachments,
+    }: { content: string; attachments?: SerializedFile[] }) => {
+      if (!isConvexId<"chat">(chatId)) {
+        return;
+      }
 
-			const controller = new AbortController();
-			store.setAbortController(controller);
+      const controller = new AbortController();
+      store.setAbortController(controller);
 
-			const selectedModel = getModelById(settings.selectedModelId);
-			const [tempUserMessage, tempAiMessage] = createTempMessages(
-				chatId,
-				content,
-				selectedModel || null,
-			);
+      const selectedModel = getModelById(settings.selectedModelId);
+      const [tempUserMessage, tempAiMessage] = createTempMessages(
+        chatId,
+        content,
+        selectedModel || null,
+      );
 
-			const attachmentCount = attachments?.length ?? 0;
-			logger.info(
-				`Sending message to chat ${chatId} (model: ${selectedModel?.name}, search: ${settings.searchEnabled}, attachments: ${attachmentCount})`,
-			);
+      const attachmentCount = attachments?.length ?? 0;
+      logger.info(
+        `Sending message to chat ${chatId} (model: ${selectedModel?.name}, search: ${settings.searchEnabled}, attachments: ${attachmentCount})`,
+      );
 
-			store.addMessages([
-				tempUserMessage as ChatMessage,
-				tempAiMessage as ChatMessage,
-			]);
+      store.addMessages([
+        tempUserMessage as ChatMessage,
+        tempAiMessage as ChatMessage,
+      ]);
 
-			try {
-				const response = await fetch("/api/chat", {
-					method: "POST",
-					signal: controller.signal,
-					body: JSON.stringify({
-						chatId,
-						modelId: settings.selectedModelId,
-						messages: [...messages, { role: "user", content }],
-						search: settings.searchEnabled,
-						reasoningEffort:
-							selectedModel && !!selectedModel.reasoningEffort
-								? settings.reasoningEffort
-								: undefined,
-						attachments,
-					}),
-				});
+      try {
+        const response = await fetch("/api/chat", {
+          method: "POST",
+          signal: controller.signal,
+          body: JSON.stringify({
+            chatId,
+            modelId: settings.selectedModelId,
+            messages: [...messages, { role: "user", content }],
+            search: settings.searchEnabled,
+            reasoningEffort:
+              selectedModel && !!selectedModel.reasoningEffort
+                ? settings.reasoningEffort
+                : undefined,
+            attachments,
+          }),
+        });
 
-				if (!response.ok || !response.body) {
-					throw new Error("Failed to append message");
-				}
+        if (!response.ok || !response.body) {
+          throw new Error("Failed to append message");
+        }
 
-				settings.resetSearchToggle();
+        settings.resetSearchToggle();
 
-				let contentBuffer = "";
-				const reasoningBuffer: MessageReasoning = {
-					text: "",
-					details: [],
-					duration: 0,
-					reasoningEffort: settings.reasoningEffort,
-				};
-				let lastReasoningPart = "";
+        let contentBuffer = "";
+        const reasoningBuffer: MessageReasoning = {
+          text: "",
+          details: [],
+          duration: 0,
+          reasoningEffort: settings.reasoningEffort,
+        };
+        let lastReasoningPart = "";
 
-				await processDataStream({
-					stream: response.body,
-					onTextPart(value) {
-						if (chatId === currentChatId) {
-							store.setStatus(ChatStatus.STREAMING);
-							contentBuffer += value;
-							store.updateLastMessage({
-								content: contentBuffer,
-								status: MessageStatus.GENERATING,
-							});
-						}
-					},
-					onReasoningPart(value) {
-						if (chatId === currentChatId) {
-							store.setStatus(ChatStatus.STREAMING);
-							if (value !== lastReasoningPart) {
-								reasoningBuffer.text += value;
-								lastReasoningPart = value;
-							}
+        await processDataStream({
+          stream: response.body,
+          onTextPart(value) {
+            if (chatId === currentChatId) {
+              store.setStatus(ChatStatus.STREAMING);
+              contentBuffer += value;
+              store.updateLastMessage({
+                content: contentBuffer,
+                status: MessageStatus.GENERATING,
+              });
+            }
+          },
+          onReasoningPart(value) {
+            if (chatId === currentChatId) {
+              store.setStatus(ChatStatus.STREAMING);
+              if (value !== lastReasoningPart) {
+                reasoningBuffer.text += value;
+                lastReasoningPart = value;
+              }
 
-							const steps = splitReasoningSteps(reasoningBuffer.text).map(
-								(step) => ({ text: step }),
-							);
-							const completedReasoning =
-								reasoningBuffer.text.length > 0
-									? {
-											text: reasoningBuffer.text,
-											details: steps,
-											duration: reasoningBuffer.duration,
-											reasoningEffort: settings.reasoningEffort,
-										}
-									: undefined;
+              const steps = splitReasoningSteps(reasoningBuffer.text).map(
+                (step) => ({ text: step }),
+              );
+              const completedReasoning =
+                reasoningBuffer.text.length > 0
+                  ? {
+                      text: reasoningBuffer.text,
+                      details: steps,
+                      duration: reasoningBuffer.duration,
+                      reasoningEffort: settings.reasoningEffort,
+                    }
+                  : undefined;
 
-							store.updateLastMessage({
-								content: contentBuffer,
-								reasoning: completedReasoning,
-								status: MessageStatus.REASONING,
-							});
-						}
-					},
-					onFinishMessagePart() {
-						if (chatId === currentChatId) {
-							const steps = splitReasoningSteps(reasoningBuffer.text).map(
-								(step) => ({ text: step }),
-							);
-							const completedReasoning =
-								reasoningBuffer.text.length > 0
-									? {
-											text: reasoningBuffer.text,
-											details: steps,
-											duration: reasoningBuffer.duration,
-											reasoningEffort: settings.reasoningEffort,
-										}
-									: undefined;
+              store.updateLastMessage({
+                content: contentBuffer,
+                reasoning: completedReasoning,
+                status: MessageStatus.REASONING,
+              });
+            }
+          },
+          onFinishMessagePart() {
+            if (chatId === currentChatId) {
+              const steps = splitReasoningSteps(reasoningBuffer.text).map(
+                (step) => ({ text: step }),
+              );
+              const completedReasoning =
+                reasoningBuffer.text.length > 0
+                  ? {
+                      text: reasoningBuffer.text,
+                      details: steps,
+                      duration: reasoningBuffer.duration,
+                      reasoningEffort: settings.reasoningEffort,
+                    }
+                  : undefined;
 
-							store.updateLastMessage({
-								content: contentBuffer,
-								reasoning: completedReasoning,
-								status: MessageStatus.COMPLETED,
-							});
-						}
-					},
-				});
-			} catch (error) {
-				if ((error as Error).name === "AbortError") {
-					if (chatId === currentChatId) {
-						store.updateLastMessage({ status: MessageStatus.ABORTED });
-					}
-				}
-			} finally {
-				if (chatId === currentChatId) {
-					store.setStatus(ChatStatus.IDLE);
-				}
-				store.setAbortController(null);
-			}
-		},
-		[
-			chatId,
-			currentChatId,
-			messages,
-			settings.selectedModelId,
-			settings.searchEnabled,
-			settings.resetSearchToggle,
-			settings.reasoningEffort,
-			store.addMessages,
-			store.setStatus,
-			store.setAbortController,
-			store.updateLastMessage,
-		],
-	);
+              store.updateLastMessage({
+                content: contentBuffer,
+                reasoning: completedReasoning,
+                status: MessageStatus.COMPLETED,
+              });
+            }
+          },
+        });
+      } catch (error) {
+        if ((error as Error).name === "AbortError") {
+          if (chatId === currentChatId) {
+            store.updateLastMessage({ status: MessageStatus.ABORTED });
+          }
+        }
+      } finally {
+        if (chatId === currentChatId) {
+          store.setStatus(ChatStatus.IDLE);
+        }
+        store.setAbortController(null);
+      }
+    },
+    [
+      chatId,
+      currentChatId,
+      messages,
+      settings.selectedModelId,
+      settings.searchEnabled,
+      settings.resetSearchToggle,
+      settings.reasoningEffort,
+      store.addMessages,
+      store.setStatus,
+      store.setAbortController,
+      store.updateLastMessage,
+    ],
+  );
 
-	const regenerate = useCallback(
-		async (upToMessageId: string) => {
-			if (!isConvexId<"chat">(chatId) || !sessionToken) {
-				return;
-			}
+  const regenerate = useCallback(
+    async (upToMessageId: string) => {
+      if (!isConvexId<"chat">(chatId) || !sessionToken) {
+        return;
+      }
 
-			// Find the index of the message we're regenerating from
-			const messageIndex = messages.findIndex((m) => m._id === upToMessageId);
-			if (messageIndex === -1) return;
+      // Find the index of the message we're regenerating from
+      const messageIndex = messages.findIndex((m) => m._id === upToMessageId);
+      if (messageIndex === -1) return;
 
-			// Get all messages up to and including the edited message
-			const messagesForRegeneration = messages.slice(0, messageIndex + 1);
+      // Get all messages up to and including the edited message
+      const messagesForRegeneration = messages.slice(0, messageIndex + 1);
 
-			const controller = new AbortController();
-			store.setAbortController(controller);
+      const controller = new AbortController();
+      store.setAbortController(controller);
 
-			const selectedModel = getModelById(settings.selectedModelId);
-			const tempAiMessage = createTempMessages(
-				chatId,
-				"",
-				selectedModel || null,
-			)[1];
+      const selectedModel = getModelById(settings.selectedModelId);
+      const tempAiMessage = createTempMessages(
+        chatId,
+        "",
+        selectedModel || null,
+      )[1];
 
-			logger.info(
-				`Regenerating AI response after message edit in chat ${chatId} (model: ${selectedModel?.name})`,
-			);
+      logger.info(
+        `Regenerating AI response after message edit in chat ${chatId} (model: ${selectedModel?.name})`,
+      );
 
-			// Only add the AI message to the store
-			store.addMessages([tempAiMessage as ChatMessage]);
+      // Enable polling to ensure we get the latest messages
+      store.setPollEnabled(true);
 
-			try {
-				const response = await fetch("/api/chat", {
-					method: "POST",
-					signal: controller.signal,
-					body: JSON.stringify({
-						chatId,
-						modelId: settings.selectedModelId,
-						messages: messagesForRegeneration.map((m) => ({
-							role: m.role,
-							content: m.content,
-						})),
-						search: settings.searchEnabled,
-						reasoningEffort:
-							selectedModel && !!selectedModel.reasoningEffort
-								? settings.reasoningEffort
-								: undefined,
-					}),
-				});
+      // Only add the AI message to the store
+      store.addMessages([tempAiMessage as ChatMessage]);
 
-				if (!response.ok || !response.body) {
-					throw new Error("Failed to regenerate response");
-				}
+      try {
+        const response = await fetch("/api/chat", {
+          method: "POST",
+          signal: controller.signal,
+          body: JSON.stringify({
+            chatId,
+            modelId: settings.selectedModelId,
+            messages: messagesForRegeneration.map((m) => ({
+              role: m.role,
+              content: m.content,
+            })),
+            search: settings.searchEnabled,
+            reasoningEffort:
+              selectedModel && !!selectedModel.reasoningEffort
+                ? settings.reasoningEffort
+                : undefined,
+          }),
+        });
 
-				settings.resetSearchToggle();
+        if (!response.ok || !response.body) {
+          throw new Error("Failed to regenerate response");
+        }
 
-				let contentBuffer = "";
-				const reasoningBuffer: MessageReasoning = {
-					text: "",
-					details: [],
-					duration: 0,
-					reasoningEffort: settings.reasoningEffort,
-				};
-				let lastReasoningPart = "";
+        settings.resetSearchToggle();
 
-				await processDataStream({
-					stream: response.body,
-					onTextPart(value) {
-						if (chatId === currentChatId) {
-							store.setStatus(ChatStatus.STREAMING);
-							contentBuffer += value;
-							store.updateLastMessage({
-								content: contentBuffer,
-								status: MessageStatus.GENERATING,
-							});
-						}
-					},
-					onReasoningPart(value) {
-						if (chatId === currentChatId) {
-							store.setStatus(ChatStatus.STREAMING);
-							if (value !== lastReasoningPart) {
-								reasoningBuffer.text += value;
-								lastReasoningPart = value;
-							}
+        let contentBuffer = "";
+        const reasoningBuffer: MessageReasoning = {
+          text: "",
+          details: [],
+          duration: 0,
+          reasoningEffort: settings.reasoningEffort,
+        };
+        let lastReasoningPart = "";
 
-							const steps = splitReasoningSteps(reasoningBuffer.text).map(
-								(step) => ({ text: step }),
-							);
-							const completedReasoning =
-								reasoningBuffer.text.length > 0
-									? {
-											text: reasoningBuffer.text,
-											details: steps,
-											duration: reasoningBuffer.duration,
-											reasoningEffort: settings.reasoningEffort,
-										}
-									: undefined;
+        await processDataStream({
+          stream: response.body,
+          onTextPart(value) {
+            if (chatId === currentChatId) {
+              store.setStatus(ChatStatus.STREAMING);
+              contentBuffer += value;
+              store.updateLastMessage({
+                content: contentBuffer,
+                status: MessageStatus.GENERATING,
+              });
+            }
+          },
+          onReasoningPart(value) {
+            if (chatId === currentChatId) {
+              store.setStatus(ChatStatus.STREAMING);
+              if (value !== lastReasoningPart) {
+                reasoningBuffer.text += value;
+                lastReasoningPart = value;
+              }
 
-							store.updateLastMessage({
-								content: contentBuffer,
-								reasoning: completedReasoning,
-								status: MessageStatus.REASONING,
-							});
-						}
-					},
-					onFinishMessagePart() {
-						if (chatId === currentChatId) {
-							const steps = splitReasoningSteps(reasoningBuffer.text).map(
-								(step) => ({ text: step }),
-							);
-							const completedReasoning =
-								reasoningBuffer.text.length > 0
-									? {
-											text: reasoningBuffer.text,
-											details: steps,
-											duration: reasoningBuffer.duration,
-											reasoningEffort: settings.reasoningEffort,
-										}
-									: undefined;
+              const steps = splitReasoningSteps(reasoningBuffer.text).map(
+                (step) => ({ text: step }),
+              );
+              const completedReasoning =
+                reasoningBuffer.text.length > 0
+                  ? {
+                      text: reasoningBuffer.text,
+                      details: steps,
+                      duration: reasoningBuffer.duration,
+                      reasoningEffort: settings.reasoningEffort,
+                    }
+                  : undefined;
 
-							store.updateLastMessage({
-								content: contentBuffer,
-								reasoning: completedReasoning,
-								status: MessageStatus.COMPLETED,
-							});
-						}
-					},
-				});
-			} catch (error) {
-				if ((error as Error).name === "AbortError") {
-					if (chatId === currentChatId) {
-						store.updateLastMessage({ status: MessageStatus.ABORTED });
-					}
-				}
-			} finally {
-				if (chatId === currentChatId) {
-					store.setStatus(ChatStatus.IDLE);
-				}
-				store.setAbortController(null);
-			}
-		},
-		[
-			chatId,
-			currentChatId,
-			messages,
-			sessionToken,
-			settings.selectedModelId,
-			settings.searchEnabled,
-			settings.resetSearchToggle,
-			settings.reasoningEffort,
-			store.addMessages,
-			store.setStatus,
-			store.setAbortController,
-			store.updateLastMessage,
-		],
-	);
+              store.updateLastMessage({
+                content: contentBuffer,
+                reasoning: completedReasoning,
+                status: MessageStatus.REASONING,
+              });
+            }
+          },
+          onFinishMessagePart() {
+            if (chatId === currentChatId) {
+              const steps = splitReasoningSteps(reasoningBuffer.text).map(
+                (step) => ({ text: step }),
+              );
+              const completedReasoning =
+                reasoningBuffer.text.length > 0
+                  ? {
+                      text: reasoningBuffer.text,
+                      details: steps,
+                      duration: reasoningBuffer.duration,
+                      reasoningEffort: settings.reasoningEffort,
+                    }
+                  : undefined;
 
-	const stop = useCallback(() => {
-		if (abortController) {
-			updateAiMessage({
-				messageId: messages[messages.length - 1]._id,
-				status: MessageStatus.ABORTED,
-				sessionToken: sessionToken ?? "skip",
-			});
-			abortController.abort();
-		}
-	}, [abortController, messages, updateAiMessage, sessionToken]);
+              store.updateLastMessage({
+                content: contentBuffer,
+                reasoning: completedReasoning,
+                status: MessageStatus.COMPLETED,
+              });
+            }
+          },
+        });
+      } catch (error) {
+        if ((error as Error).name === "AbortError") {
+          if (chatId === currentChatId) {
+            store.updateLastMessage({ status: MessageStatus.ABORTED });
+          }
+        }
+      } finally {
+        if (chatId === currentChatId) {
+          store.setStatus(ChatStatus.IDLE);
+        }
+        store.setAbortController(null);
+      }
+    },
+    [
+      chatId,
+      currentChatId,
+      messages,
+      sessionToken,
+      settings.selectedModelId,
+      settings.searchEnabled,
+      settings.resetSearchToggle,
+      settings.reasoningEffort,
+      store.addMessages,
+      store.setStatus,
+      store.setAbortController,
+      store.updateLastMessage,
+      store.setPollEnabled,
+    ],
+  );
 
-	return {
-		messages,
-		isLoadingMessages: !getChatMessages || !sessionToken,
-		status,
-		append,
-		regenerate,
-		stop,
-		selectedModelId: settings.selectedModelId,
-		setSelectedModelId: settings.setSelectedModelId,
-		searchEnabled: settings.searchEnabled,
-		setSearchEnabled: settings.setSearchEnabled,
-	} as const;
+  const stop = useCallback(() => {
+    if (abortController) {
+      updateAiMessage({
+        messageId: messages[messages.length - 1]._id,
+        status: MessageStatus.ABORTED,
+        sessionToken: sessionToken ?? "skip",
+      });
+      abortController.abort();
+    }
+  }, [abortController, messages, updateAiMessage, sessionToken]);
+
+  return {
+    messages,
+    isLoadingMessages: !getChatMessages || !sessionToken,
+    status,
+    append,
+    regenerate,
+    stop,
+    selectedModelId: settings.selectedModelId,
+    setSelectedModelId: settings.setSelectedModelId,
+    searchEnabled: settings.searchEnabled,
+    setSearchEnabled: settings.setSearchEnabled,
+  } as const;
 }

--- a/apps/web/src/hooks/use-chat.ts
+++ b/apps/web/src/hooks/use-chat.ts
@@ -1,16 +1,16 @@
 import { useMutation, useQuery } from "convex/react";
 import { useCallback, useEffect } from "react";
 import {
-  type ChatMessage,
-  ChatStatus,
-  type MessageReasoning,
-  MessageStatus,
+	type ChatMessage,
+	ChatStatus,
+	type MessageReasoning,
+	MessageStatus,
 } from "~/components/chat/types";
 import { useChatSettings } from "~/hooks/use-chat-settings";
 import { useChatStore, useChatStoreSubscription } from "~/hooks/use-chat-store";
 import {
-  createTempMessages,
-  shouldEnablePolling,
+	createTempMessages,
+	shouldEnablePolling,
 } from "~/hooks/use-chat-utils";
 import { usePolling } from "~/hooks/use-polling";
 import { processDataStream } from "~/lib/ai/process-chat-response";
@@ -23,254 +23,411 @@ import { logger } from "~/lib/logger";
 import { getModelById } from "~/lib/models";
 
 export function useChat(chatId: string | undefined) {
-  const { data: session } = authClient.useSession();
-  const sessionToken = session?.session.token;
+	const { data: session } = authClient.useSession();
+	const sessionToken = session?.session.token;
 
-  const settings = useChatSettings();
-  const store = useChatStore(chatId);
+	const settings = useChatSettings();
+	const store = useChatStore(chatId);
 
-  const messages = useChatStoreSubscription(chatId, (state) => state.messages);
-  const status = useChatStoreSubscription(chatId, (state) => state.status);
-  const abortController = useChatStoreSubscription(
-    chatId,
-    (state) => state.abortController,
-  );
-  const currentChatId = useChatStoreSubscription(
-    chatId,
-    (state) => state.currentChatId,
-  );
-  const isInitialLoad = useChatStoreSubscription(
-    chatId,
-    (state) => state.isInitialLoad,
-  );
-  const pollEnabled = useChatStoreSubscription(
-    chatId,
-    (state) => state.pollEnabled,
-  );
+	const messages = useChatStoreSubscription(chatId, (state) => state.messages);
+	const status = useChatStoreSubscription(chatId, (state) => state.status);
+	const abortController = useChatStoreSubscription(
+		chatId,
+		(state) => state.abortController,
+	);
+	const currentChatId = useChatStoreSubscription(
+		chatId,
+		(state) => state.currentChatId,
+	);
+	const isInitialLoad = useChatStoreSubscription(
+		chatId,
+		(state) => state.isInitialLoad,
+	);
+	const pollEnabled = useChatStoreSubscription(
+		chatId,
+		(state) => state.pollEnabled,
+	);
 
-  const updateAiMessage = useMutation(api.functions.message.updateAiMessage);
-  const getChatMessages = useQuery(
-    api.functions.chat.getChatMessages,
-    isConvexId<"chat">(chatId) && sessionToken && (isInitialLoad || pollEnabled)
-      ? { chatId: chatId, sessionToken }
-      : "skip",
-  );
+	const updateAiMessage = useMutation(api.functions.message.updateAiMessage);
+	const getChatMessages = useQuery(
+		api.functions.chat.getChatMessages,
+		isConvexId<"chat">(chatId) && sessionToken && (isInitialLoad || pollEnabled)
+			? { chatId: chatId, sessionToken }
+			: "skip",
+	);
 
-  usePolling({
-    enabled: pollEnabled,
-    onPoll: () => {
-      const lastMessage = messages[messages.length - 1];
-      logger.debug(
-        `Polling for message updates in chat ${chatId} (${messages.length} messages, last status: ${lastMessage?.status || "none"})`,
-      );
-    },
-  });
+	usePolling({
+		enabled: pollEnabled,
+		onPoll: () => {
+			const lastMessage = messages[messages.length - 1];
+			logger.debug(
+				`Polling for message updates in chat ${chatId} (${messages.length} messages, last status: ${lastMessage?.status || "none"})`,
+			);
+		},
+	});
 
-  useEffect(() => {
-    if (chatId !== currentChatId) {
-      store.resetChat(chatId);
-    }
-  }, [chatId, currentChatId, store.resetChat]);
+	useEffect(() => {
+		if (chatId !== currentChatId) {
+			store.resetChat(chatId);
+		}
+	}, [chatId, currentChatId, store.resetChat]);
 
-  useEffect(() => {
-    if (!getChatMessages || chatId !== currentChatId || !sessionToken) {
-      return;
-    }
+	useEffect(() => {
+		if (!getChatMessages || chatId !== currentChatId || !sessionToken) {
+			return;
+		}
 
-    store.setMessages(getChatMessages);
+		store.setMessages(getChatMessages);
 
-    if (isInitialLoad) {
-      store.setInitialLoad(false);
-      if (shouldEnablePolling(getChatMessages)) {
-        store.setPollEnabled(true);
-      }
-    } else if (pollEnabled && !shouldEnablePolling(getChatMessages)) {
-      store.setPollEnabled(false);
-    }
-  }, [
-    getChatMessages,
-    chatId,
-    currentChatId,
-    sessionToken,
-    isInitialLoad,
-    pollEnabled,
-    store.setMessages,
-    store.setInitialLoad,
-    store.setPollEnabled,
-  ]);
+		if (isInitialLoad) {
+			store.setInitialLoad(false);
+			if (shouldEnablePolling(getChatMessages)) {
+				store.setPollEnabled(true);
+			}
+		} else if (pollEnabled && !shouldEnablePolling(getChatMessages)) {
+			store.setPollEnabled(false);
+		}
+	}, [
+		getChatMessages,
+		chatId,
+		currentChatId,
+		sessionToken,
+		isInitialLoad,
+		pollEnabled,
+		store.setMessages,
+		store.setInitialLoad,
+		store.setPollEnabled,
+	]);
 
-  const append = useCallback(
-    async ({
-      content,
-      attachments,
-    }: { content: string; attachments?: SerializedFile[] }) => {
-      if (!isConvexId<"chat">(chatId)) {
-        return;
-      }
+	const append = useCallback(
+		async ({
+			content,
+			attachments,
+		}: { content: string; attachments?: SerializedFile[] }) => {
+			if (!isConvexId<"chat">(chatId)) {
+				return;
+			}
 
-      const controller = new AbortController();
-      store.setAbortController(controller);
+			const controller = new AbortController();
+			store.setAbortController(controller);
 
-      const selectedModel = getModelById(settings.selectedModelId);
-      const [tempUserMessage, tempAiMessage] = createTempMessages(
-        chatId,
-        content,
-        selectedModel || null,
-      );
+			const selectedModel = getModelById(settings.selectedModelId);
+			const [tempUserMessage, tempAiMessage] = createTempMessages(
+				chatId,
+				content,
+				selectedModel || null,
+			);
 
-      const attachmentCount = attachments?.length ?? 0;
-      logger.info(
-        `Sending message to chat ${chatId} (model: ${selectedModel?.name}, search: ${settings.searchEnabled}, attachments: ${attachmentCount})`,
-      );
+			const attachmentCount = attachments?.length ?? 0;
+			logger.info(
+				`Sending message to chat ${chatId} (model: ${selectedModel?.name}, search: ${settings.searchEnabled}, attachments: ${attachmentCount})`,
+			);
 
-      store.addMessages([
-        tempUserMessage as ChatMessage,
-        tempAiMessage as ChatMessage,
-      ]);
+			store.addMessages([
+				tempUserMessage as ChatMessage,
+				tempAiMessage as ChatMessage,
+			]);
 
-      try {
-        const response = await fetch("/api/chat", {
-          method: "POST",
-          signal: controller.signal,
-          body: JSON.stringify({
-            chatId,
-            modelId: settings.selectedModelId,
-            messages: [...messages, { role: "user", content }],
-            search: settings.searchEnabled,
-            reasoningEffort:
-              selectedModel && !!selectedModel.reasoningEffort
-                ? settings.reasoningEffort
-                : undefined,
-            attachments,
-          }),
-        });
+			try {
+				const response = await fetch("/api/chat", {
+					method: "POST",
+					signal: controller.signal,
+					body: JSON.stringify({
+						chatId,
+						modelId: settings.selectedModelId,
+						messages: [...messages, { role: "user", content }],
+						search: settings.searchEnabled,
+						reasoningEffort:
+							selectedModel && !!selectedModel.reasoningEffort
+								? settings.reasoningEffort
+								: undefined,
+						attachments,
+					}),
+				});
 
-        if (!response.ok || !response.body) {
-          throw new Error("Failed to append message");
-        }
+				if (!response.ok || !response.body) {
+					throw new Error("Failed to append message");
+				}
 
-        settings.resetSearchToggle();
+				settings.resetSearchToggle();
 
-        let contentBuffer = "";
-        const reasoningBuffer: MessageReasoning = {
-          text: "",
-          details: [],
-          duration: 0,
-          reasoningEffort: settings.reasoningEffort,
-        };
-        let lastReasoningPart = "";
+				let contentBuffer = "";
+				const reasoningBuffer: MessageReasoning = {
+					text: "",
+					details: [],
+					duration: 0,
+					reasoningEffort: settings.reasoningEffort,
+				};
+				let lastReasoningPart = "";
 
-        await processDataStream({
-          stream: response.body,
-          onTextPart(value) {
-            if (chatId === currentChatId) {
-              store.setStatus(ChatStatus.STREAMING);
-              contentBuffer += value;
-              store.updateLastMessage({
-                content: contentBuffer,
-                status: MessageStatus.GENERATING,
-              });
-            }
-          },
-          onReasoningPart(value) {
-            if (chatId === currentChatId) {
-              store.setStatus(ChatStatus.STREAMING);
-              if (value !== lastReasoningPart) {
-                reasoningBuffer.text += value;
-                lastReasoningPart = value;
-              }
+				await processDataStream({
+					stream: response.body,
+					onTextPart(value) {
+						if (chatId === currentChatId) {
+							store.setStatus(ChatStatus.STREAMING);
+							contentBuffer += value;
+							store.updateLastMessage({
+								content: contentBuffer,
+								status: MessageStatus.GENERATING,
+							});
+						}
+					},
+					onReasoningPart(value) {
+						if (chatId === currentChatId) {
+							store.setStatus(ChatStatus.STREAMING);
+							if (value !== lastReasoningPart) {
+								reasoningBuffer.text += value;
+								lastReasoningPart = value;
+							}
 
-              const steps = splitReasoningSteps(reasoningBuffer.text).map(
-                (step) => ({ text: step }),
-              );
-              const completedReasoning =
-                reasoningBuffer.text.length > 0
-                  ? {
-                      text: reasoningBuffer.text,
-                      details: steps,
-                      duration: reasoningBuffer.duration,
-                      reasoningEffort: settings.reasoningEffort,
-                    }
-                  : undefined;
+							const steps = splitReasoningSteps(reasoningBuffer.text).map(
+								(step) => ({ text: step }),
+							);
+							const completedReasoning =
+								reasoningBuffer.text.length > 0
+									? {
+											text: reasoningBuffer.text,
+											details: steps,
+											duration: reasoningBuffer.duration,
+											reasoningEffort: settings.reasoningEffort,
+										}
+									: undefined;
 
-              store.updateLastMessage({
-                content: contentBuffer,
-                reasoning: completedReasoning,
-                status: MessageStatus.REASONING,
-              });
-            }
-          },
-          onFinishMessagePart() {
-            if (chatId === currentChatId) {
-              const steps = splitReasoningSteps(reasoningBuffer.text).map(
-                (step) => ({ text: step }),
-              );
-              const completedReasoning =
-                reasoningBuffer.text.length > 0
-                  ? {
-                      text: reasoningBuffer.text,
-                      details: steps,
-                      duration: reasoningBuffer.duration,
-                      reasoningEffort: settings.reasoningEffort,
-                    }
-                  : undefined;
+							store.updateLastMessage({
+								content: contentBuffer,
+								reasoning: completedReasoning,
+								status: MessageStatus.REASONING,
+							});
+						}
+					},
+					onFinishMessagePart() {
+						if (chatId === currentChatId) {
+							const steps = splitReasoningSteps(reasoningBuffer.text).map(
+								(step) => ({ text: step }),
+							);
+							const completedReasoning =
+								reasoningBuffer.text.length > 0
+									? {
+											text: reasoningBuffer.text,
+											details: steps,
+											duration: reasoningBuffer.duration,
+											reasoningEffort: settings.reasoningEffort,
+										}
+									: undefined;
 
-              store.updateLastMessage({
-                content: contentBuffer,
-                reasoning: completedReasoning,
-                status: MessageStatus.COMPLETED,
-              });
-            }
-          },
-        });
-      } catch (error) {
-        if ((error as Error).name === "AbortError") {
-          if (chatId === currentChatId) {
-            store.updateLastMessage({ status: MessageStatus.ABORTED });
-          }
-        }
-      } finally {
-        if (chatId === currentChatId) {
-          store.setStatus(ChatStatus.IDLE);
-        }
-        store.setAbortController(null);
-      }
-    },
-    [
-      chatId,
-      currentChatId,
-      messages,
-      settings.selectedModelId,
-      settings.searchEnabled,
-      settings.resetSearchToggle,
-      settings.reasoningEffort,
-      store.addMessages,
-      store.setStatus,
-      store.setAbortController,
-      store.updateLastMessage,
-    ],
-  );
+							store.updateLastMessage({
+								content: contentBuffer,
+								reasoning: completedReasoning,
+								status: MessageStatus.COMPLETED,
+							});
+						}
+					},
+				});
+			} catch (error) {
+				if ((error as Error).name === "AbortError") {
+					if (chatId === currentChatId) {
+						store.updateLastMessage({ status: MessageStatus.ABORTED });
+					}
+				}
+			} finally {
+				if (chatId === currentChatId) {
+					store.setStatus(ChatStatus.IDLE);
+				}
+				store.setAbortController(null);
+			}
+		},
+		[
+			chatId,
+			currentChatId,
+			messages,
+			settings.selectedModelId,
+			settings.searchEnabled,
+			settings.resetSearchToggle,
+			settings.reasoningEffort,
+			store.addMessages,
+			store.setStatus,
+			store.setAbortController,
+			store.updateLastMessage,
+		],
+	);
 
-  const stop = useCallback(() => {
-    if (abortController) {
-      updateAiMessage({
-        messageId: messages[messages.length - 1]._id,
-        status: MessageStatus.ABORTED,
-        sessionToken: sessionToken ?? "skip",
-      });
-      abortController.abort();
-    }
-  }, [abortController, messages, updateAiMessage, sessionToken]);
+	const regenerate = useCallback(
+		async (upToMessageId: string) => {
+			if (!isConvexId<"chat">(chatId) || !sessionToken) {
+				return;
+			}
 
-  return {
-    messages,
-    isLoadingMessages: !getChatMessages || !sessionToken,
-    status,
-    append,
-    stop,
-    selectedModelId: settings.selectedModelId,
-    setSelectedModelId: settings.setSelectedModelId,
-    searchEnabled: settings.searchEnabled,
-    setSearchEnabled: settings.setSearchEnabled,
-  } as const;
+			// Find the index of the message we're regenerating from
+			const messageIndex = messages.findIndex((m) => m._id === upToMessageId);
+			if (messageIndex === -1) return;
+
+			// Get all messages up to and including the edited message
+			const messagesForRegeneration = messages.slice(0, messageIndex + 1);
+
+			const controller = new AbortController();
+			store.setAbortController(controller);
+
+			const selectedModel = getModelById(settings.selectedModelId);
+			const tempAiMessage = createTempMessages(
+				chatId,
+				"",
+				selectedModel || null,
+			)[1];
+
+			logger.info(
+				`Regenerating AI response after message edit in chat ${chatId} (model: ${selectedModel?.name})`,
+			);
+
+			// Only add the AI message to the store
+			store.addMessages([tempAiMessage as ChatMessage]);
+
+			try {
+				const response = await fetch("/api/chat", {
+					method: "POST",
+					signal: controller.signal,
+					body: JSON.stringify({
+						chatId,
+						modelId: settings.selectedModelId,
+						messages: messagesForRegeneration.map((m) => ({
+							role: m.role,
+							content: m.content,
+						})),
+						search: settings.searchEnabled,
+						reasoningEffort:
+							selectedModel && !!selectedModel.reasoningEffort
+								? settings.reasoningEffort
+								: undefined,
+					}),
+				});
+
+				if (!response.ok || !response.body) {
+					throw new Error("Failed to regenerate response");
+				}
+
+				settings.resetSearchToggle();
+
+				let contentBuffer = "";
+				const reasoningBuffer: MessageReasoning = {
+					text: "",
+					details: [],
+					duration: 0,
+					reasoningEffort: settings.reasoningEffort,
+				};
+				let lastReasoningPart = "";
+
+				await processDataStream({
+					stream: response.body,
+					onTextPart(value) {
+						if (chatId === currentChatId) {
+							store.setStatus(ChatStatus.STREAMING);
+							contentBuffer += value;
+							store.updateLastMessage({
+								content: contentBuffer,
+								status: MessageStatus.GENERATING,
+							});
+						}
+					},
+					onReasoningPart(value) {
+						if (chatId === currentChatId) {
+							store.setStatus(ChatStatus.STREAMING);
+							if (value !== lastReasoningPart) {
+								reasoningBuffer.text += value;
+								lastReasoningPart = value;
+							}
+
+							const steps = splitReasoningSteps(reasoningBuffer.text).map(
+								(step) => ({ text: step }),
+							);
+							const completedReasoning =
+								reasoningBuffer.text.length > 0
+									? {
+											text: reasoningBuffer.text,
+											details: steps,
+											duration: reasoningBuffer.duration,
+											reasoningEffort: settings.reasoningEffort,
+										}
+									: undefined;
+
+							store.updateLastMessage({
+								content: contentBuffer,
+								reasoning: completedReasoning,
+								status: MessageStatus.REASONING,
+							});
+						}
+					},
+					onFinishMessagePart() {
+						if (chatId === currentChatId) {
+							const steps = splitReasoningSteps(reasoningBuffer.text).map(
+								(step) => ({ text: step }),
+							);
+							const completedReasoning =
+								reasoningBuffer.text.length > 0
+									? {
+											text: reasoningBuffer.text,
+											details: steps,
+											duration: reasoningBuffer.duration,
+											reasoningEffort: settings.reasoningEffort,
+										}
+									: undefined;
+
+							store.updateLastMessage({
+								content: contentBuffer,
+								reasoning: completedReasoning,
+								status: MessageStatus.COMPLETED,
+							});
+						}
+					},
+				});
+			} catch (error) {
+				if ((error as Error).name === "AbortError") {
+					if (chatId === currentChatId) {
+						store.updateLastMessage({ status: MessageStatus.ABORTED });
+					}
+				}
+			} finally {
+				if (chatId === currentChatId) {
+					store.setStatus(ChatStatus.IDLE);
+				}
+				store.setAbortController(null);
+			}
+		},
+		[
+			chatId,
+			currentChatId,
+			messages,
+			sessionToken,
+			settings.selectedModelId,
+			settings.searchEnabled,
+			settings.resetSearchToggle,
+			settings.reasoningEffort,
+			store.addMessages,
+			store.setStatus,
+			store.setAbortController,
+			store.updateLastMessage,
+		],
+	);
+
+	const stop = useCallback(() => {
+		if (abortController) {
+			updateAiMessage({
+				messageId: messages[messages.length - 1]._id,
+				status: MessageStatus.ABORTED,
+				sessionToken: sessionToken ?? "skip",
+			});
+			abortController.abort();
+		}
+	}, [abortController, messages, updateAiMessage, sessionToken]);
+
+	return {
+		messages,
+		isLoadingMessages: !getChatMessages || !sessionToken,
+		status,
+		append,
+		regenerate,
+		stop,
+		selectedModelId: settings.selectedModelId,
+		setSelectedModelId: settings.setSelectedModelId,
+		searchEnabled: settings.searchEnabled,
+		setSearchEnabled: settings.setSearchEnabled,
+	} as const;
 }

--- a/apps/web/src/hooks/use-chat.ts
+++ b/apps/web/src/hooks/use-chat.ts
@@ -252,7 +252,7 @@ export function useChat(chatId: string | undefined) {
   );
 
   const regenerate = useCallback(
-    async (upToMessageId: string) => {
+    async (upToMessageId: string, editedContent?: string) => {
       if (!isConvexId<"chat">(chatId) || !sessionToken) {
         return;
       }
@@ -262,7 +262,19 @@ export function useChat(chatId: string | undefined) {
       if (messageIndex === -1) return;
 
       // Get all messages up to and including the edited message
-      const messagesForRegeneration = messages.slice(0, messageIndex + 1);
+      // If editedContent is provided, update the last user message with it
+      const messagesForRegeneration = messages
+        .slice(0, messageIndex + 1)
+        .map((msg, idx) => {
+          if (
+            idx === messageIndex &&
+            editedContent !== undefined &&
+            msg.role === "user"
+          ) {
+            return { ...msg, content: editedContent };
+          }
+          return msg;
+        });
 
       const controller = new AbortController();
       store.setAbortController(controller);

--- a/apps/web/src/routes/api/chat.ts
+++ b/apps/web/src/routes/api/chat.ts
@@ -1,17 +1,17 @@
 import {
-  createServerFileRoute,
-  getWebRequest,
+	createServerFileRoute,
+	getWebRequest,
 } from "@tanstack/react-start/server";
 import { waitUntil } from "@vercel/functions";
 import { streamText } from "ai";
 import type { Tool, ToolSet } from "ai";
 import type { Id } from "convex/_generated/dataModel";
 import {
-  type AttachmentId,
-  type MessageId,
-  type MessageReasoning,
-  MessageStatus,
-  type MessageUsage,
+	type AttachmentId,
+	type MessageId,
+	type MessageReasoning,
+	MessageStatus,
+	type MessageUsage,
 } from "~/components/chat/types";
 import { mathEvaluation } from "~/lib/ai/mathEvaluation";
 import { splitReasoningSteps } from "~/lib/ai/reasoning";
@@ -24,681 +24,683 @@ import { getDefaultModel, getModelById, getSystemPrompt } from "~/lib/models";
 import { openrouter } from "~/lib/openrouter";
 
 type AttachmentData = {
-  name: string;
-  size: number;
-  type: string;
-  data: string;
+	name: string;
+	size: number;
+	type: string;
+	data: string;
 };
 
 type ProcessedAttachment = {
-  type: string;
-  name: string;
-  mimeType: string;
-  url: string;
-  extractedText?: string;
+	type: string;
+	name: string;
+	mimeType: string;
+	url: string;
+	extractedText?: string;
 };
 
 type AttachmentFromDb = {
-  type: string;
-  name: string;
-  mimeType?: string;
-  url: string;
-  extractedText?: string;
+	type: string;
+	name: string;
+	mimeType?: string;
+	url: string;
+	extractedText?: string;
 };
 
 type MessageContent = {
-  type: string;
-  text?: string;
-  image?: string;
+	type: string;
+	text?: string;
+	image?: string;
 };
 
 type StreamingState = {
-  contentBuffer: string;
-  reasoningBuffer: {
-    text: string;
-    details: { text: string }[];
-    duration: number;
-    reasoningEffort?: string;
-  };
-  lastReasoningDelta: string;
-  lastReasoningUpdate: number;
-  usage: {
-    promptTokens: number;
-    completionTokens: number;
-    totalTokens: number;
-  };
-  isAborted: boolean;
-  lastUpdate: number;
-  finishReason?: string;
-  hasToolErrors: boolean;
+	contentBuffer: string;
+	reasoningBuffer: {
+		text: string;
+		details: { text: string }[];
+		duration: number;
+		reasoningEffort?: string;
+	};
+	lastReasoningDelta: string;
+	lastReasoningUpdate: number;
+	usage: {
+		promptTokens: number;
+		completionTokens: number;
+		totalTokens: number;
+	};
+	isAborted: boolean;
+	lastUpdate: number;
+	finishReason?: string;
+	hasToolErrors: boolean;
 };
 
 // Database operations
 const createAiMessage = async ({
-  chatId,
-  sessionToken,
-  provider,
-  model,
+	chatId,
+	sessionToken,
+	provider,
+	model,
 }: {
-  chatId: Id<"chat">;
-  sessionToken: string;
-  provider: string;
-  model: string;
+	chatId: Id<"chat">;
+	sessionToken: string;
+	provider: string;
+	model: string;
 }) => {
-  return await convexServer.mutation(api.functions.message.createAiMessage, {
-    chatId,
-    provider,
-    model,
-    sessionToken,
-  });
+	return await convexServer.mutation(api.functions.message.createAiMessage, {
+		chatId,
+		provider,
+		model,
+		sessionToken,
+	});
 };
 
 const updateAiMessage = async ({
-  messageId,
-  content,
-  reasoning,
-  status,
-  model,
-  provider,
-  usage,
-  historyEntry,
-  sessionToken,
+	messageId,
+	content,
+	reasoning,
+	status,
+	model,
+	provider,
+	usage,
+	historyEntry,
+	sessionToken,
 }: {
-  messageId: MessageId;
-  content: string;
-  reasoning?: MessageReasoning;
-  status: string;
-  sessionToken: string;
-  model?: string;
-  provider?: string;
-  usage?: MessageUsage;
-  historyEntry?: {
-    version: number;
-    content: string;
-    status: string;
-    reasoning?: MessageReasoning;
-    provider: string;
-    model: string;
-    usage?: MessageUsage;
-  };
+	messageId: MessageId;
+	content: string;
+	reasoning?: MessageReasoning;
+	status: string;
+	sessionToken: string;
+	model?: string;
+	provider?: string;
+	usage?: MessageUsage;
+	historyEntry?: {
+		version: number;
+		content: string;
+		status: string;
+		reasoning?: MessageReasoning;
+		provider: string;
+		model: string;
+		usage?: MessageUsage;
+	};
 }) => {
-  await convexServer.mutation(api.functions.message.updateAiMessage, {
-    messageId,
-    content,
-    reasoning,
-    status,
-    model,
-    provider,
-    usage,
-    sessionToken,
-    historyEntry,
-  });
+	await convexServer.mutation(api.functions.message.updateAiMessage, {
+		messageId,
+		content,
+		reasoning,
+		status,
+		model,
+		provider,
+		usage,
+		sessionToken,
+		historyEntry,
+	});
 };
 
 const getMessageStatus = async ({
-  messageId,
-  sessionToken,
+	messageId,
+	sessionToken,
 }: {
-  messageId: MessageId;
-  sessionToken: string;
+	messageId: MessageId;
+	sessionToken: string;
 }) => {
-  return await convexServer.query(api.functions.message.getMessageStatus, {
-    messageId,
-    sessionToken,
-  });
+	return await convexServer.query(api.functions.message.getMessageStatus, {
+		messageId,
+		sessionToken,
+	});
 };
 
 // Attachment processing utilities
 const separateAttachments = (attachments: (string | object)[]) => {
-  const existingAttachmentIds = attachments.filter(
-    (att) => typeof att === "string" && att.startsWith("k"),
-  ) as string[];
-  const newAttachments = attachments.filter(
-    (att) => typeof att === "object" && att !== null && "data" in att,
-  ) as AttachmentData[];
-  return { existingAttachmentIds, newAttachments };
+	const existingAttachmentIds = attachments.filter(
+		(att) => typeof att === "string" && att.startsWith("k"),
+	) as string[];
+	const newAttachments = attachments.filter(
+		(att) => typeof att === "object" && att !== null && "data" in att,
+	) as AttachmentData[];
+	return { existingAttachmentIds, newAttachments };
 };
 
 const fetchExistingAttachments = async (
-  existingAttachmentIds: string[],
-  sessionToken: string,
+	existingAttachmentIds: string[],
+	sessionToken: string,
 ) => {
-  return await Promise.all(
-    existingAttachmentIds.map(async (attachmentId) => {
-      try {
-        return await convexServer.query(
-          api.functions.attachment.getAttachment,
-          {
-            attachmentId: attachmentId as AttachmentId,
-            sessionToken,
-          },
-        );
-      } catch (error) {
-        logger.error(
-          `Failed to fetch attachment ${attachmentId} from database: ${error}`,
-        );
-        return null;
-      }
-    }),
-  );
+	return await Promise.all(
+		existingAttachmentIds.map(async (attachmentId) => {
+			try {
+				return await convexServer.query(
+					api.functions.attachment.getAttachment,
+					{
+						attachmentId: attachmentId as AttachmentId,
+						sessionToken,
+					},
+				);
+			} catch (error) {
+				logger.error(
+					`Failed to fetch attachment ${attachmentId} from database: ${error}`,
+				);
+				return null;
+			}
+		}),
+	);
 };
 
 const processAttachmentsForAI = (
-  existingAttachmentsData: (AttachmentFromDb | null)[],
-  newAttachments: AttachmentData[],
+	existingAttachmentsData: (AttachmentFromDb | null)[],
+	newAttachments: AttachmentData[],
 ): ProcessedAttachment[] => {
-  return [
-    ...existingAttachmentsData
-      .filter((att): att is AttachmentFromDb => att !== null)
-      .map((att) => ({
-        type: att.type,
-        name: att.name,
-        mimeType: att.mimeType || "application/octet-stream",
-        url: att.url,
-        extractedText: att.extractedText,
-      })),
-    ...newAttachments.map((att) => ({
-      type: att.type.startsWith("image/") ? "image" : "document",
-      name: att.name,
-      mimeType: att.type,
-      url: `data:${att.type};base64,${att.data}`,
-      extractedText: undefined,
-    })),
-  ];
+	return [
+		...existingAttachmentsData
+			.filter((att): att is AttachmentFromDb => att !== null)
+			.map((att) => ({
+				type: att.type,
+				name: att.name,
+				mimeType: att.mimeType || "application/octet-stream",
+				url: att.url,
+				extractedText: att.extractedText,
+			})),
+		...newAttachments.map((att) => ({
+			type: att.type.startsWith("image/") ? "image" : "document",
+			name: att.name,
+			mimeType: att.type,
+			url: `data:${att.type};base64,${att.data}`,
+			extractedText: undefined,
+		})),
+	];
 };
 
 const transformMessageWithAttachments = (
-  lastMessage: { content: string; [key: string]: unknown },
-  allAttachmentsForAI: ProcessedAttachment[],
+	lastMessage: { content: string; [key: string]: unknown },
+	allAttachmentsForAI: ProcessedAttachment[],
 ) => {
-  const messageContent: MessageContent[] = [];
+	const messageContent: MessageContent[] = [];
 
-  if (lastMessage.content.trim()) {
-    messageContent.push({ type: "text", text: lastMessage.content });
-  }
+	if (lastMessage.content.trim()) {
+		messageContent.push({ type: "text", text: lastMessage.content });
+	}
 
-  for (const attachment of allAttachmentsForAI) {
-    if (attachment.type === "image") {
-      messageContent.push({
-        type: "image",
-        image: attachment.url,
-      });
-    } else if (attachment.type === "pdf" || attachment.type === "document") {
-      messageContent.push({
-        type: "text",
-        text: `[File: ${attachment.name} (${attachment.mimeType})]${
-          attachment.extractedText
-            ? `\n\nContent:\n${attachment.extractedText}`
-            : ""
-        }`,
-      });
-    }
-  }
+	for (const attachment of allAttachmentsForAI) {
+		if (attachment.type === "image") {
+			messageContent.push({
+				type: "image",
+				image: attachment.url,
+			});
+		} else if (attachment.type === "pdf" || attachment.type === "document") {
+			messageContent.push({
+				type: "text",
+				text: `[File: ${attachment.name} (${attachment.mimeType})]${
+					attachment.extractedText
+						? `\n\nContent:\n${attachment.extractedText}`
+						: ""
+				}`,
+			});
+		}
+	}
 
-  return messageContent;
+	return messageContent;
 };
 
 const convertBase64ToBlob = (base64Data: string, mimeType: string): Blob => {
-  const binary = atob(base64Data);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return new Blob([bytes], { type: mimeType });
+	const binary = atob(base64Data);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return new Blob([bytes], { type: mimeType });
 };
 
 const uploadSingleAttachment = async (
-  attachment: AttachmentData,
-  userMessageId: MessageId,
-  sessionToken: string,
+	attachment: AttachmentData,
+	userMessageId: MessageId,
+	sessionToken: string,
 ): Promise<string | null> => {
-  try {
-    // Generate upload URL
-    const uploadUrl = await convexServer.mutation(
-      api.functions.attachment.generateUploadUrl,
-      { sessionToken },
-    );
+	try {
+		// Generate upload URL
+		const uploadUrl = await convexServer.mutation(
+			api.functions.attachment.generateUploadUrl,
+			{ sessionToken },
+		);
 
-    // Convert base64 to blob
-    const blob = convertBase64ToBlob(attachment.data, attachment.type);
+		// Convert base64 to blob
+		const blob = convertBase64ToBlob(attachment.data, attachment.type);
 
-    // Upload to Convex storage
-    const uploadResult = await fetch(uploadUrl, {
-      method: "POST",
-      headers: { "Content-Type": attachment.type },
-      body: blob,
-    });
+		// Upload to Convex storage
+		const uploadResult = await fetch(uploadUrl, {
+			method: "POST",
+			headers: { "Content-Type": attachment.type },
+			body: blob,
+		});
 
-    if (!uploadResult.ok) {
-      throw new Error("Upload failed");
-    }
+		if (!uploadResult.ok) {
+			throw new Error("Upload failed");
+		}
 
-    const { storageId } = await uploadResult.json();
+		const { storageId } = await uploadResult.json();
 
-    // Create attachment record
-    const attachmentId = await convexServer.mutation(
-      api.functions.attachment.createAttachment,
-      {
-        storageId,
-        messageId: userMessageId,
-        name: attachment.name,
-        size: attachment.size,
-        mimeType: attachment.type,
-        sessionToken,
-      },
-    );
+		// Create attachment record
+		const attachmentId = await convexServer.mutation(
+			api.functions.attachment.createAttachment,
+			{
+				storageId,
+				messageId: userMessageId,
+				name: attachment.name,
+				size: attachment.size,
+				mimeType: attachment.type,
+				sessionToken,
+			},
+		);
 
-    return attachmentId as string;
-  } catch (error) {
-    logger.error(
-      `Failed to upload attachment "${attachment.name}" (${attachment.type}): ${error}`,
-    );
-    return null;
-  }
+		return attachmentId as string;
+	} catch (error) {
+		logger.error(
+			`Failed to upload attachment "${attachment.name}" (${attachment.type}): ${error}`,
+		);
+		return null;
+	}
 };
 
 const processAttachmentsInBackground = async (
-  newAttachments: AttachmentData[],
-  userMessageId: MessageId,
-  existingAttachmentIds: string[],
-  sessionToken: string,
+	newAttachments: AttachmentData[],
+	userMessageId: MessageId,
+	existingAttachmentIds: string[],
+	sessionToken: string,
 ) => {
-  try {
-    const uploadPromises = newAttachments.map((attachment) =>
-      uploadSingleAttachment(attachment, userMessageId, sessionToken),
-    );
+	try {
+		const uploadPromises = newAttachments.map((attachment) =>
+			uploadSingleAttachment(attachment, userMessageId, sessionToken),
+		);
 
-    const uploadedAttachmentIds = await Promise.all(uploadPromises);
-    const successfulUploads = uploadedAttachmentIds.filter(
-      (id): id is string => id !== null,
-    );
+		const uploadedAttachmentIds = await Promise.all(uploadPromises);
+		const successfulUploads = uploadedAttachmentIds.filter(
+			(id): id is string => id !== null,
+		);
 
-    // Combine existing and new attachment IDs for updating the message
-    const allAttachmentIds = [...existingAttachmentIds, ...successfulUploads];
+		// Combine existing and new attachment IDs for updating the message
+		const allAttachmentIds = [...existingAttachmentIds, ...successfulUploads];
 
-    // Update message with all attachment IDs
-    if (allAttachmentIds.length > 0) {
-      await convexServer.mutation(api.functions.message.updateUserMessage, {
-        messageId: userMessageId,
-        sessionToken,
-        attachments: allAttachmentIds.map((id) => id as AttachmentId),
-      });
-    }
-  } catch (error) {
-    logger.error(`Failed to process attachments in background: ${error}`);
-  }
+		// Update message with all attachment IDs
+		if (allAttachmentIds.length > 0) {
+			await convexServer.mutation(api.functions.message.updateUserMessage, {
+				messageId: userMessageId,
+				sessionToken,
+				attachments: allAttachmentIds.map((id) => id as AttachmentId),
+			});
+		}
+	} catch (error) {
+		logger.error(`Failed to process attachments in background: ${error}`);
+	}
 };
 
 const updateChatMetadata = async (
-  chatId: Id<"chat">,
-  modelId: string,
-  provider: string,
-  sessionToken: string,
+	chatId: Id<"chat">,
+	modelId: string,
+	provider: string,
+	sessionToken: string,
 ) => {
-  try {
-    await convexServer.mutation(api.functions.chat.updateChat, {
-      chatId,
-      model: modelId,
-      provider,
-      sessionToken,
-    });
-  } catch (err) {
-    logger.warn(`Failed to update chat model metadata: ${err}`);
-  }
+	try {
+		await convexServer.mutation(api.functions.chat.updateChat, {
+			chatId,
+			model: modelId,
+			provider,
+			sessionToken,
+		});
+	} catch (err) {
+		logger.warn(`Failed to update chat model metadata: ${err}`);
+	}
 };
 
 export const ServerRoute = createServerFileRoute("/api/chat").methods({
-  GET: ({ request: _ }) => {
-    return new Response("What do you think chat?");
-  },
-  POST: async ({ request }) => {
-    const session = await auth.api.getSession({
-      headers: getWebRequest()?.headers ?? new Headers(),
-    });
+	GET: ({ request: _ }) => {
+		return new Response("What do you think chat?");
+	},
+	POST: async ({ request }) => {
+		const session = await auth.api.getSession({
+			headers: getWebRequest()?.headers ?? new Headers(),
+		});
 
-    if (!session) {
-      return new Response("Unauthorized", { status: 401 });
-    }
+		if (!session) {
+			return new Response("Unauthorized", { status: 401 });
+		}
 
-    const sessionToken = session.session.token;
-    const {
-      messages,
-      chatId,
-      modelId: requestedModelId,
-      search = false,
-      reasoningEffort,
-      attachments = [],
-    } = await request.json();
+		const sessionToken = session.session.token;
+		const {
+			messages,
+			chatId,
+			modelId: requestedModelId,
+			search = false,
+			reasoningEffort,
+			attachments = [],
+			isRegeneration = false, // New flag to indicate if this is a regeneration
+		} = await request.json();
 
-    const lastMessage = messages[messages.length - 1];
-    let transformedMessages = messages;
+		const lastMessage = messages[messages.length - 1];
+		let transformedMessages = messages;
 
-    if (lastMessage.role === "user") {
-      const userMessageId = await convexServer.mutation(
-        api.functions.message.createUserMessage,
-        {
-          chatId,
-          content: lastMessage.content,
-          sessionToken,
-        },
-      );
+		// Only create a new user message if this is NOT a regeneration
+		if (lastMessage.role === "user" && !isRegeneration) {
+			const userMessageId = await convexServer.mutation(
+				api.functions.message.createUserMessage,
+				{
+					chatId,
+					content: lastMessage.content,
+					sessionToken,
+				},
+			);
 
-      // Transform messages with attachment content for AI model
-      if (attachments.length > 0) {
-        const { existingAttachmentIds, newAttachments } =
-          separateAttachments(attachments);
+			// Transform messages with attachment content for AI model
+			if (attachments.length > 0) {
+				const { existingAttachmentIds, newAttachments } =
+					separateAttachments(attachments);
 
-        // Fetch existing attachments data if any
-        const existingAttachmentsData = await fetchExistingAttachments(
-          existingAttachmentIds,
-          sessionToken,
-        );
+				// Fetch existing attachments data if any
+				const existingAttachmentsData = await fetchExistingAttachments(
+					existingAttachmentIds,
+					sessionToken,
+				);
 
-        // Combine all attachments for message transformation
-        const allAttachmentsForAI = processAttachmentsForAI(
-          existingAttachmentsData,
-          newAttachments,
-        );
+				// Combine all attachments for message transformation
+				const allAttachmentsForAI = processAttachmentsForAI(
+					existingAttachmentsData,
+					newAttachments,
+				);
 
-        // Transform last message to include attachments for AI
-        if (allAttachmentsForAI.length > 0) {
-          const messageContent = transformMessageWithAttachments(
-            lastMessage,
-            allAttachmentsForAI,
-          );
+				// Transform last message to include attachments for AI
+				if (allAttachmentsForAI.length > 0) {
+					const messageContent = transformMessageWithAttachments(
+						lastMessage,
+						allAttachmentsForAI,
+					);
 
-          // Update transformedMessages with multimodal content
-          transformedMessages = [
-            ...messages.slice(0, -1),
-            {
-              ...lastMessage,
-              content: messageContent,
-            },
-          ];
-        }
+					// Update transformedMessages with multimodal content
+					transformedMessages = [
+						...messages.slice(0, -1),
+						{
+							...lastMessage,
+							content: messageContent,
+						},
+					];
+				}
 
-        // Process attachments in background (fire-and-forget) - only for new attachments
-        if (newAttachments.length > 0 && userMessageId) {
-          waitUntil(
-            processAttachmentsInBackground(
-              newAttachments,
-              userMessageId,
-              existingAttachmentIds,
-              sessionToken,
-            ),
-          );
-        }
-      }
-    }
+				// Process attachments in background (fire-and-forget) - only for new attachments
+				if (newAttachments.length > 0 && userMessageId) {
+					waitUntil(
+						processAttachmentsInBackground(
+							newAttachments,
+							userMessageId,
+							existingAttachmentIds,
+							sessionToken,
+						),
+					);
+				}
+			}
+		}
 
-    const selectedModel = requestedModelId
-      ? getModelById(requestedModelId)
-      : getDefaultModel();
-    if (!selectedModel) {
-      return new Response("Invalid model selection", { status: 400 });
-    }
+		const selectedModel = requestedModelId
+			? getModelById(requestedModelId)
+			: getDefaultModel();
+		if (!selectedModel) {
+			return new Response("Invalid model selection", { status: 400 });
+		}
 
-    const { provider, modelId } = selectedModel;
+		const { provider, modelId } = selectedModel;
 
-    logger.info(
-      `Starting chat stream: ${chatId} (model: ${selectedModel.name}, search: ${search}${reasoningEffort ? `, reasoning: ${reasoningEffort}` : ""})`,
-    );
+		logger.info(
+			`Starting chat stream: ${chatId} (model: ${selectedModel.name}, search: ${search}${reasoningEffort ? `, reasoning: ${reasoningEffort}` : ""})`,
+		);
 
-    const providerOptions =
-      reasoningEffort && selectedModel.reasoningEffort
-        ? { openrouter: { reasoning: { effort: reasoningEffort } } }
-        : undefined;
+		const providerOptions =
+			reasoningEffort && selectedModel.reasoningEffort
+				? { openrouter: { reasoning: { effort: reasoningEffort } } }
+				: undefined;
 
-    const toolSet = (
-      search ? { mathEvaluation, webSearch } : { mathEvaluation }
-    ) as ToolSet;
-    const maxSteps = selectedModel.reasoningEffort
-      ? search
-        ? 5
-        : 3
-      : search
-        ? 7
-        : 5;
+		const toolSet = (
+			search ? { mathEvaluation, webSearch } : { mathEvaluation }
+		) as ToolSet;
+		const maxSteps = selectedModel.reasoningEffort
+			? search
+				? 5
+				: 3
+			: search
+				? 7
+				: 5;
 
-    try {
-      const result = streamText({
-        model: openrouter.chat(modelId),
-        system: getSystemPrompt(selectedModel, session.user.name, search),
-        messages: transformedMessages,
-        abortSignal: request.signal,
-        ...(providerOptions ? { providerOptions } : {}),
-        tools: toolSet,
-        maxSteps,
-      });
+		try {
+			const result = streamText({
+				model: openrouter.chat(modelId),
+				system: getSystemPrompt(selectedModel, session.user.name, search),
+				messages: transformedMessages,
+				abortSignal: request.signal,
+				...(providerOptions ? { providerOptions } : {}),
+				tools: toolSet,
+				maxSteps,
+			});
 
-      const messageId = await createAiMessage({
-        chatId,
-        sessionToken,
-        provider,
-        model: selectedModel.name,
-      });
+			const messageId = await createAiMessage({
+				chatId,
+				sessionToken,
+				provider,
+				model: selectedModel.name,
+			});
 
-      if (!messageId) {
-        return new Response("Failed to create AI message", {
-          status: API_CONSTANTS.STATUS_CODES.INTERNAL_SERVER_ERROR,
-        });
-      }
+			if (!messageId) {
+				return new Response("Failed to create AI message", {
+					status: API_CONSTANTS.STATUS_CODES.INTERNAL_SERVER_ERROR,
+				});
+			}
 
-      waitUntil(
-        updateChatMetadata(
-          chatId,
-          selectedModel.modelId,
-          provider,
-          sessionToken,
-        ),
-      );
+			waitUntil(
+				updateChatMetadata(
+					chatId,
+					selectedModel.modelId,
+					provider,
+					sessionToken,
+				),
+			);
 
-      // Start streaming processing in the background
-      waitUntil(
-        processStreamingResponse(
-          result,
-          messageId,
-          sessionToken,
-          reasoningEffort,
-          selectedModel,
-          provider,
-          chatId,
-        ),
-      );
+			// Start streaming processing in the background
+			waitUntil(
+				processStreamingResponse(
+					result,
+					messageId,
+					sessionToken,
+					reasoningEffort,
+					selectedModel,
+					provider,
+					chatId,
+				),
+			);
 
-      return result.toDataStreamResponse({
-        sendReasoning: true,
-      });
-    } catch (error) {
-      logger.error(`Chat streaming failed for ${chatId}: ${error}`);
-      return new Response("Error streaming chat", {
-        status: API_CONSTANTS.STATUS_CODES.INTERNAL_SERVER_ERROR,
-      });
-    }
-  },
+			return result.toDataStreamResponse({
+				sendReasoning: true,
+			});
+		} catch (error) {
+			logger.error(`Chat streaming failed for ${chatId}: ${error}`);
+			return new Response("Error streaming chat", {
+				status: API_CONSTANTS.STATUS_CODES.INTERNAL_SERVER_ERROR,
+			});
+		}
+	},
 });
 
 // Streaming response processing
 const processStreamingResponse = async (
-  // biome-ignore lint/suspicious/noExplicitAny: no easy way to type this
-  result: any,
-  messageId: MessageId,
-  sessionToken: string,
-  reasoningEffort: string | undefined,
-  selectedModel: ReturnType<typeof getModelById>,
-  provider: string,
-  _chatId: Id<"chat">,
+	// biome-ignore lint/suspicious/noExplicitAny: no easy way to type this
+	result: any,
+	messageId: MessageId,
+	sessionToken: string,
+	reasoningEffort: string | undefined,
+	selectedModel: ReturnType<typeof getModelById>,
+	provider: string,
+	_chatId: Id<"chat">,
 ) => {
-  const state: StreamingState = {
-    contentBuffer: "",
-    reasoningBuffer: {
-      text: "",
-      details: [],
-      duration: 0,
-      reasoningEffort,
-    },
-    lastReasoningDelta: "",
-    lastReasoningUpdate: 0,
-    usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
-    isAborted: false,
-    lastUpdate: 0,
-    finishReason: undefined,
-    hasToolErrors: false,
-  };
+	const state: StreamingState = {
+		contentBuffer: "",
+		reasoningBuffer: {
+			text: "",
+			details: [],
+			duration: 0,
+			reasoningEffort,
+		},
+		lastReasoningDelta: "",
+		lastReasoningUpdate: 0,
+		usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+		isAborted: false,
+		lastUpdate: 0,
+		finishReason: undefined,
+		hasToolErrors: false,
+	};
 
-  const processReasoning = (textDelta: string) => {
-    const cleanedDelta = textDelta?.replace(/\0/g, "") || "";
-    state.reasoningBuffer.text = cleanedDelta;
-    const steps = splitReasoningSteps(cleanedDelta);
-    state.reasoningBuffer.details = steps.map((step) => ({ text: step }));
-    state.lastReasoningDelta = cleanedDelta;
-    state.lastReasoningUpdate = Date.now();
-  };
+	const processReasoning = (textDelta: string) => {
+		const cleanedDelta = textDelta?.replace(/\0/g, "") || "";
+		state.reasoningBuffer.text = cleanedDelta;
+		const steps = splitReasoningSteps(cleanedDelta);
+		state.reasoningBuffer.details = steps.map((step) => ({ text: step }));
+		state.lastReasoningDelta = cleanedDelta;
+		state.lastReasoningUpdate = Date.now();
+	};
 
-  const shouldUpdateMessage = () => {
-    const now = Date.now();
-    return (
-      now - state.lastUpdate > UI_CONSTANTS.POLLING_INTERVALS.UPDATE_INTERVAL ||
-      now - state.lastReasoningUpdate >
-        UI_CONSTANTS.POLLING_INTERVALS.SLOW_UPDATE
-    );
-  };
+	const shouldUpdateMessage = () => {
+		const now = Date.now();
+		return (
+			now - state.lastUpdate > UI_CONSTANTS.POLLING_INTERVALS.UPDATE_INTERVAL ||
+			now - state.lastReasoningUpdate >
+				UI_CONSTANTS.POLLING_INTERVALS.SLOW_UPDATE
+		);
+	};
 
-  const updateMessage = async (status = MessageStatus.STREAMING) => {
-    if (!shouldUpdateMessage() && status === MessageStatus.STREAMING) return;
+	const updateMessage = async (status = MessageStatus.STREAMING) => {
+		if (!shouldUpdateMessage() && status === MessageStatus.STREAMING) return;
 
-    const currentReasoning =
-      state.reasoningBuffer.details.length > 0
-        ? state.reasoningBuffer
-        : undefined;
-    const currentUsage = state.usage.totalTokens > 0 ? state.usage : undefined;
+		const currentReasoning =
+			state.reasoningBuffer.details.length > 0
+				? state.reasoningBuffer
+				: undefined;
+		const currentUsage = state.usage.totalTokens > 0 ? state.usage : undefined;
 
-    await updateAiMessage({
-      messageId,
-      content: state.contentBuffer,
-      reasoning: currentReasoning,
-      status,
-      model: selectedModel?.name,
-      provider,
-      usage: currentUsage,
-      sessionToken,
-    });
+		await updateAiMessage({
+			messageId,
+			content: state.contentBuffer,
+			reasoning: currentReasoning,
+			status,
+			model: selectedModel?.name,
+			provider,
+			usage: currentUsage,
+			sessionToken,
+		});
 
-    state.lastUpdate = Date.now();
-  };
+		state.lastUpdate = Date.now();
+	};
 
-  try {
-    for await (const chunk of result.fullStream) {
-      switch (chunk.type) {
-        case "text-delta":
-          state.contentBuffer += chunk.textDelta;
-          await updateMessage();
-          break;
+	try {
+		for await (const chunk of result.fullStream) {
+			switch (chunk.type) {
+				case "text-delta":
+					state.contentBuffer += chunk.textDelta;
+					await updateMessage();
+					break;
 
-        case "reasoning":
-          processReasoning(chunk.textDelta);
-          await updateMessage();
-          break;
+				case "reasoning":
+					processReasoning(chunk.textDelta);
+					await updateMessage();
+					break;
 
-        case "tool-call":
-          logger.info(`Tool call: ${chunk.toolName}`);
-          break;
+				case "tool-call":
+					logger.info(`Tool call: ${chunk.toolName}`);
+					break;
 
-        case "tool-result":
-          logger.info(`Tool result: ${chunk.toolName}`);
-          if (
-            chunk.result &&
-            typeof chunk.result === "object" &&
-            "error" in chunk.result
-          ) {
-            logger.warn(
-              `Tool execution error in ${chunk.toolName}: ${chunk.result.error}`,
-            );
-            state.hasToolErrors = true;
-          }
-          break;
+				case "tool-result":
+					logger.info(`Tool result: ${chunk.toolName}`);
+					if (
+						chunk.result &&
+						typeof chunk.result === "object" &&
+						"error" in chunk.result
+					) {
+						logger.warn(
+							`Tool execution error in ${chunk.toolName}: ${chunk.result.error}`,
+						);
+						state.hasToolErrors = true;
+					}
+					break;
 
-        case "error": {
-          const errorString = String(chunk.error);
-          if (errorString.includes("AI_ToolExecutionError")) {
-            logger.warn(`Tool execution error: ${errorString}`);
-            state.hasToolErrors = true;
-          } else {
-            logger.error(`Streaming error: ${chunk.error}`);
-            state.isAborted = true;
-          }
-          break;
-        }
+				case "error": {
+					const errorString = String(chunk.error);
+					if (errorString.includes("AI_ToolExecutionError")) {
+						logger.warn(`Tool execution error: ${errorString}`);
+						state.hasToolErrors = true;
+					} else {
+						logger.error(`Streaming error: ${chunk.error}`);
+						state.isAborted = true;
+					}
+					break;
+				}
 
-        case "finish":
-          state.finishReason = chunk.finishReason;
-          logger.info(`Streaming finished: ${chunk.finishReason}`);
+				case "finish":
+					state.finishReason = chunk.finishReason;
+					logger.info(`Streaming finished: ${chunk.finishReason}`);
 
-          if (chunk.finishReason === "stop" && state.hasToolErrors) {
-            logger.warn(
-              "Model stopped early likely due to tool execution errors - completing message gracefully",
-            );
-          } else if (chunk.finishReason === "length") {
-            logger.warn(
-              "Model stopped due to length limit - message may be truncated",
-            );
-          } else if (chunk.finishReason === "tool-calls") {
-            logger.info("Model finished after tool calls");
-          }
-          break;
+					if (chunk.finishReason === "stop" && state.hasToolErrors) {
+						logger.warn(
+							"Model stopped early likely due to tool execution errors - completing message gracefully",
+						);
+					} else if (chunk.finishReason === "length") {
+						logger.warn(
+							"Model stopped due to length limit - message may be truncated",
+						);
+					} else if (chunk.finishReason === "tool-calls") {
+						logger.info("Model finished after tool calls");
+					}
+					break;
 
-        default:
-          break;
-      }
-    }
+				default:
+					break;
+			}
+		}
 
-    if (!state.isAborted) {
-      const messageStatus = await getMessageStatus({ messageId, sessionToken });
+		if (!state.isAborted) {
+			const messageStatus = await getMessageStatus({ messageId, sessionToken });
 
-      let finalStatus = MessageStatus.COMPLETED;
+			let finalStatus = MessageStatus.COMPLETED;
 
-      if (
-        (state.finishReason === "stop" ||
-          state.finishReason === "tool-calls") &&
-        state.hasToolErrors
-      ) {
-        if (state.contentBuffer.trim().length === 0) {
-          state.contentBuffer =
-            "I encountered an error while trying to evaluate that mathematical expression. Please check the function name or expression format and try again.";
-          logger.info(
-            `Added fallback content for empty message with tool errors: ${messageId}`,
-          );
-        }
-        logger.info(
-          `Completing message gracefully despite early stop due to tool errors: ${messageId}`,
-        );
-        finalStatus = MessageStatus.COMPLETED;
-      } else if (state.finishReason === "length") {
-        logger.info(
-          `Message completed but may be truncated due to length: ${messageId}`,
-        );
-        finalStatus = MessageStatus.COMPLETED;
-      }
+			if (
+				(state.finishReason === "stop" ||
+					state.finishReason === "tool-calls") &&
+				state.hasToolErrors
+			) {
+				if (state.contentBuffer.trim().length === 0) {
+					state.contentBuffer =
+						"I encountered an error while trying to evaluate that mathematical expression. Please check the function name or expression format and try again.";
+					logger.info(
+						`Added fallback content for empty message with tool errors: ${messageId}`,
+					);
+				}
+				logger.info(
+					`Completing message gracefully despite early stop due to tool errors: ${messageId}`,
+				);
+				finalStatus = MessageStatus.COMPLETED;
+			} else if (state.finishReason === "length") {
+				logger.info(
+					`Message completed but may be truncated due to length: ${messageId}`,
+				);
+				finalStatus = MessageStatus.COMPLETED;
+			}
 
-      if (messageStatus === MessageStatus.STREAMING || state.hasToolErrors) {
-        await updateMessage(finalStatus);
-        logger.info(
-          `Message completed with status ${finalStatus}: ${messageId}`,
-        );
-      } else {
-        logger.warn(
-          `Message not in streaming status and no tool errors, current status: ${messageStatus}`,
-        );
-      }
-    } else {
-      logger.warn("Stream was aborted, not processing completion");
-    }
-  } catch (error) {
-    logger.error(`Streaming processing failed: ${error}`);
-    state.isAborted = true;
-    const messageStatus = await getMessageStatus({ messageId, sessionToken });
-    if (messageStatus === MessageStatus.STREAMING) {
-      await updateMessage(MessageStatus.FAILED);
-    }
-  }
+			if (messageStatus === MessageStatus.STREAMING || state.hasToolErrors) {
+				await updateMessage(finalStatus);
+				logger.info(
+					`Message completed with status ${finalStatus}: ${messageId}`,
+				);
+			} else {
+				logger.warn(
+					`Message not in streaming status and no tool errors, current status: ${messageStatus}`,
+				);
+			}
+		} else {
+			logger.warn("Stream was aborted, not processing completion");
+		}
+	} catch (error) {
+		logger.error(`Streaming processing failed: ${error}`);
+		state.isAborted = true;
+		const messageStatus = await getMessageStatus({ messageId, sessionToken });
+		if (messageStatus === MessageStatus.STREAMING) {
+			await updateMessage(MessageStatus.FAILED);
+		}
+	}
 };

--- a/apps/web/src/routes/api/chat.ts
+++ b/apps/web/src/routes/api/chat.ts
@@ -1,17 +1,17 @@
 import {
-	createServerFileRoute,
-	getWebRequest,
+  createServerFileRoute,
+  getWebRequest,
 } from "@tanstack/react-start/server";
 import { waitUntil } from "@vercel/functions";
 import { streamText } from "ai";
 import type { Tool, ToolSet } from "ai";
 import type { Id } from "convex/_generated/dataModel";
 import {
-	type AttachmentId,
-	type MessageId,
-	type MessageReasoning,
-	MessageStatus,
-	type MessageUsage,
+  type AttachmentId,
+  type MessageId,
+  type MessageReasoning,
+  MessageStatus,
+  type MessageUsage,
 } from "~/components/chat/types";
 import { mathEvaluation } from "~/lib/ai/mathEvaluation";
 import { splitReasoningSteps } from "~/lib/ai/reasoning";
@@ -24,681 +24,681 @@ import { getDefaultModel, getModelById, getSystemPrompt } from "~/lib/models";
 import { openrouter } from "~/lib/openrouter";
 
 type AttachmentData = {
-	name: string;
-	size: number;
-	type: string;
-	data: string;
+  name: string;
+  size: number;
+  type: string;
+  data: string;
 };
 
 type ProcessedAttachment = {
-	type: string;
-	name: string;
-	mimeType: string;
-	url: string;
-	extractedText?: string;
+  type: string;
+  name: string;
+  mimeType: string;
+  url: string;
+  extractedText?: string;
 };
 
 type AttachmentFromDb = {
-	type: string;
-	name: string;
-	mimeType?: string;
-	url: string;
-	extractedText?: string;
+  type: string;
+  name: string;
+  mimeType?: string;
+  url: string;
+  extractedText?: string;
 };
 
 type MessageContent = {
-	type: string;
-	text?: string;
-	image?: string;
+  type: string;
+  text?: string;
+  image?: string;
 };
 
 type StreamingState = {
-	contentBuffer: string;
-	reasoningBuffer: {
-		text: string;
-		details: { text: string }[];
-		duration: number;
-		reasoningEffort?: string;
-	};
-	lastReasoningDelta: string;
-	lastReasoningUpdate: number;
-	usage: {
-		promptTokens: number;
-		completionTokens: number;
-		totalTokens: number;
-	};
-	isAborted: boolean;
-	lastUpdate: number;
-	finishReason?: string;
-	hasToolErrors: boolean;
+  contentBuffer: string;
+  reasoningBuffer: {
+    text: string;
+    details: { text: string }[];
+    duration: number;
+    reasoningEffort?: string;
+  };
+  lastReasoningDelta: string;
+  lastReasoningUpdate: number;
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  isAborted: boolean;
+  lastUpdate: number;
+  finishReason?: string;
+  hasToolErrors: boolean;
 };
 
 // Database operations
 const createAiMessage = async ({
-	chatId,
-	sessionToken,
-	provider,
-	model,
+  chatId,
+  sessionToken,
+  provider,
+  model,
 }: {
-	chatId: Id<"chat">;
-	sessionToken: string;
-	provider: string;
-	model: string;
+  chatId: Id<"chat">;
+  sessionToken: string;
+  provider: string;
+  model: string;
 }) => {
-	return await convexServer.mutation(api.functions.message.createAiMessage, {
-		chatId,
-		provider,
-		model,
-		sessionToken,
-	});
+  return await convexServer.mutation(api.functions.message.createAiMessage, {
+    chatId,
+    provider,
+    model,
+    sessionToken,
+  });
 };
 
 const updateAiMessage = async ({
-	messageId,
-	content,
-	reasoning,
-	status,
-	model,
-	provider,
-	usage,
-	historyEntry,
-	sessionToken,
+  messageId,
+  content,
+  reasoning,
+  status,
+  model,
+  provider,
+  usage,
+  historyEntry,
+  sessionToken,
 }: {
-	messageId: MessageId;
-	content: string;
-	reasoning?: MessageReasoning;
-	status: string;
-	sessionToken: string;
-	model?: string;
-	provider?: string;
-	usage?: MessageUsage;
-	historyEntry?: {
-		version: number;
-		content: string;
-		status: string;
-		reasoning?: MessageReasoning;
-		provider: string;
-		model: string;
-		usage?: MessageUsage;
-	};
+  messageId: MessageId;
+  content: string;
+  reasoning?: MessageReasoning;
+  status: string;
+  sessionToken: string;
+  model?: string;
+  provider?: string;
+  usage?: MessageUsage;
+  historyEntry?: {
+    version: number;
+    content: string;
+    status: string;
+    reasoning?: MessageReasoning;
+    provider: string;
+    model: string;
+    usage?: MessageUsage;
+  };
 }) => {
-	await convexServer.mutation(api.functions.message.updateAiMessage, {
-		messageId,
-		content,
-		reasoning,
-		status,
-		model,
-		provider,
-		usage,
-		sessionToken,
-		historyEntry,
-	});
+  await convexServer.mutation(api.functions.message.updateAiMessage, {
+    messageId,
+    content,
+    reasoning,
+    status,
+    model,
+    provider,
+    usage,
+    sessionToken,
+    historyEntry,
+  });
 };
 
 const getMessageStatus = async ({
-	messageId,
-	sessionToken,
+  messageId,
+  sessionToken,
 }: {
-	messageId: MessageId;
-	sessionToken: string;
+  messageId: MessageId;
+  sessionToken: string;
 }) => {
-	return await convexServer.query(api.functions.message.getMessageStatus, {
-		messageId,
-		sessionToken,
-	});
+  return await convexServer.query(api.functions.message.getMessageStatus, {
+    messageId,
+    sessionToken,
+  });
 };
 
 // Attachment processing utilities
 const separateAttachments = (attachments: (string | object)[]) => {
-	const existingAttachmentIds = attachments.filter(
-		(att) => typeof att === "string" && att.startsWith("k"),
-	) as string[];
-	const newAttachments = attachments.filter(
-		(att) => typeof att === "object" && att !== null && "data" in att,
-	) as AttachmentData[];
-	return { existingAttachmentIds, newAttachments };
+  const existingAttachmentIds = attachments.filter(
+    (att) => typeof att === "string" && att.startsWith("k"),
+  ) as string[];
+  const newAttachments = attachments.filter(
+    (att) => typeof att === "object" && att !== null && "data" in att,
+  ) as AttachmentData[];
+  return { existingAttachmentIds, newAttachments };
 };
 
 const fetchExistingAttachments = async (
-	existingAttachmentIds: string[],
-	sessionToken: string,
+  existingAttachmentIds: string[],
+  sessionToken: string,
 ) => {
-	return await Promise.all(
-		existingAttachmentIds.map(async (attachmentId) => {
-			try {
-				return await convexServer.query(
-					api.functions.attachment.getAttachment,
-					{
-						attachmentId: attachmentId as AttachmentId,
-						sessionToken,
-					},
-				);
-			} catch (error) {
-				logger.error(
-					`Failed to fetch attachment ${attachmentId} from database: ${error}`,
-				);
-				return null;
-			}
-		}),
-	);
+  return await Promise.all(
+    existingAttachmentIds.map(async (attachmentId) => {
+      try {
+        return await convexServer.query(
+          api.functions.attachment.getAttachment,
+          {
+            attachmentId: attachmentId as AttachmentId,
+            sessionToken,
+          },
+        );
+      } catch (error) {
+        logger.error(
+          `Failed to fetch attachment ${attachmentId} from database: ${error}`,
+        );
+        return null;
+      }
+    }),
+  );
 };
 
 const processAttachmentsForAI = (
-	existingAttachmentsData: (AttachmentFromDb | null)[],
-	newAttachments: AttachmentData[],
+  existingAttachmentsData: (AttachmentFromDb | null)[],
+  newAttachments: AttachmentData[],
 ): ProcessedAttachment[] => {
-	return [
-		...existingAttachmentsData
-			.filter((att): att is AttachmentFromDb => att !== null)
-			.map((att) => ({
-				type: att.type,
-				name: att.name,
-				mimeType: att.mimeType || "application/octet-stream",
-				url: att.url,
-				extractedText: att.extractedText,
-			})),
-		...newAttachments.map((att) => ({
-			type: att.type.startsWith("image/") ? "image" : "document",
-			name: att.name,
-			mimeType: att.type,
-			url: `data:${att.type};base64,${att.data}`,
-			extractedText: undefined,
-		})),
-	];
+  return [
+    ...existingAttachmentsData
+      .filter((att): att is AttachmentFromDb => att !== null)
+      .map((att) => ({
+        type: att.type,
+        name: att.name,
+        mimeType: att.mimeType || "application/octet-stream",
+        url: att.url,
+        extractedText: att.extractedText,
+      })),
+    ...newAttachments.map((att) => ({
+      type: att.type.startsWith("image/") ? "image" : "document",
+      name: att.name,
+      mimeType: att.type,
+      url: `data:${att.type};base64,${att.data}`,
+      extractedText: undefined,
+    })),
+  ];
 };
 
 const transformMessageWithAttachments = (
-	lastMessage: { content: string; [key: string]: unknown },
-	allAttachmentsForAI: ProcessedAttachment[],
+  lastMessage: { content: string; [key: string]: unknown },
+  allAttachmentsForAI: ProcessedAttachment[],
 ) => {
-	const messageContent: MessageContent[] = [];
+  const messageContent: MessageContent[] = [];
 
-	if (lastMessage.content.trim()) {
-		messageContent.push({ type: "text", text: lastMessage.content });
-	}
+  if (lastMessage.content.trim()) {
+    messageContent.push({ type: "text", text: lastMessage.content });
+  }
 
-	for (const attachment of allAttachmentsForAI) {
-		if (attachment.type === "image") {
-			messageContent.push({
-				type: "image",
-				image: attachment.url,
-			});
-		} else if (attachment.type === "pdf" || attachment.type === "document") {
-			messageContent.push({
-				type: "text",
-				text: `[File: ${attachment.name} (${attachment.mimeType})]${
-					attachment.extractedText
-						? `\n\nContent:\n${attachment.extractedText}`
-						: ""
-				}`,
-			});
-		}
-	}
+  for (const attachment of allAttachmentsForAI) {
+    if (attachment.type === "image") {
+      messageContent.push({
+        type: "image",
+        image: attachment.url,
+      });
+    } else if (attachment.type === "pdf" || attachment.type === "document") {
+      messageContent.push({
+        type: "text",
+        text: `[File: ${attachment.name} (${attachment.mimeType})]${
+          attachment.extractedText
+            ? `\n\nContent:\n${attachment.extractedText}`
+            : ""
+        }`,
+      });
+    }
+  }
 
-	return messageContent;
+  return messageContent;
 };
 
 const convertBase64ToBlob = (base64Data: string, mimeType: string): Blob => {
-	const binary = atob(base64Data);
-	const bytes = new Uint8Array(binary.length);
-	for (let i = 0; i < binary.length; i++) {
-		bytes[i] = binary.charCodeAt(i);
-	}
-	return new Blob([bytes], { type: mimeType });
+  const binary = atob(base64Data);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: mimeType });
 };
 
 const uploadSingleAttachment = async (
-	attachment: AttachmentData,
-	userMessageId: MessageId,
-	sessionToken: string,
+  attachment: AttachmentData,
+  userMessageId: MessageId,
+  sessionToken: string,
 ): Promise<string | null> => {
-	try {
-		// Generate upload URL
-		const uploadUrl = await convexServer.mutation(
-			api.functions.attachment.generateUploadUrl,
-			{ sessionToken },
-		);
+  try {
+    // Generate upload URL
+    const uploadUrl = await convexServer.mutation(
+      api.functions.attachment.generateUploadUrl,
+      { sessionToken },
+    );
 
-		// Convert base64 to blob
-		const blob = convertBase64ToBlob(attachment.data, attachment.type);
+    // Convert base64 to blob
+    const blob = convertBase64ToBlob(attachment.data, attachment.type);
 
-		// Upload to Convex storage
-		const uploadResult = await fetch(uploadUrl, {
-			method: "POST",
-			headers: { "Content-Type": attachment.type },
-			body: blob,
-		});
+    // Upload to Convex storage
+    const uploadResult = await fetch(uploadUrl, {
+      method: "POST",
+      headers: { "Content-Type": attachment.type },
+      body: blob,
+    });
 
-		if (!uploadResult.ok) {
-			throw new Error("Upload failed");
-		}
+    if (!uploadResult.ok) {
+      throw new Error("Upload failed");
+    }
 
-		const { storageId } = await uploadResult.json();
+    const { storageId } = await uploadResult.json();
 
-		// Create attachment record
-		const attachmentId = await convexServer.mutation(
-			api.functions.attachment.createAttachment,
-			{
-				storageId,
-				messageId: userMessageId,
-				name: attachment.name,
-				size: attachment.size,
-				mimeType: attachment.type,
-				sessionToken,
-			},
-		);
+    // Create attachment record
+    const attachmentId = await convexServer.mutation(
+      api.functions.attachment.createAttachment,
+      {
+        storageId,
+        messageId: userMessageId,
+        name: attachment.name,
+        size: attachment.size,
+        mimeType: attachment.type,
+        sessionToken,
+      },
+    );
 
-		return attachmentId as string;
-	} catch (error) {
-		logger.error(
-			`Failed to upload attachment "${attachment.name}" (${attachment.type}): ${error}`,
-		);
-		return null;
-	}
+    return attachmentId as string;
+  } catch (error) {
+    logger.error(
+      `Failed to upload attachment "${attachment.name}" (${attachment.type}): ${error}`,
+    );
+    return null;
+  }
 };
 
 const processAttachmentsInBackground = async (
-	newAttachments: AttachmentData[],
-	userMessageId: MessageId,
-	existingAttachmentIds: string[],
-	sessionToken: string,
+  newAttachments: AttachmentData[],
+  userMessageId: MessageId,
+  existingAttachmentIds: string[],
+  sessionToken: string,
 ) => {
-	try {
-		const uploadPromises = newAttachments.map((attachment) =>
-			uploadSingleAttachment(attachment, userMessageId, sessionToken),
-		);
+  try {
+    const uploadPromises = newAttachments.map((attachment) =>
+      uploadSingleAttachment(attachment, userMessageId, sessionToken),
+    );
 
-		const uploadedAttachmentIds = await Promise.all(uploadPromises);
-		const successfulUploads = uploadedAttachmentIds.filter(
-			(id): id is string => id !== null,
-		);
+    const uploadedAttachmentIds = await Promise.all(uploadPromises);
+    const successfulUploads = uploadedAttachmentIds.filter(
+      (id): id is string => id !== null,
+    );
 
-		// Combine existing and new attachment IDs for updating the message
-		const allAttachmentIds = [...existingAttachmentIds, ...successfulUploads];
+    // Combine existing and new attachment IDs for updating the message
+    const allAttachmentIds = [...existingAttachmentIds, ...successfulUploads];
 
-		// Update message with all attachment IDs
-		if (allAttachmentIds.length > 0) {
-			await convexServer.mutation(api.functions.message.updateUserMessage, {
-				messageId: userMessageId,
-				sessionToken,
-				attachments: allAttachmentIds.map((id) => id as AttachmentId),
-			});
-		}
-	} catch (error) {
-		logger.error(`Failed to process attachments in background: ${error}`);
-	}
+    // Update message with all attachment IDs
+    if (allAttachmentIds.length > 0) {
+      await convexServer.mutation(api.functions.message.updateUserMessage, {
+        messageId: userMessageId,
+        sessionToken,
+        attachments: allAttachmentIds.map((id) => id as AttachmentId),
+      });
+    }
+  } catch (error) {
+    logger.error(`Failed to process attachments in background: ${error}`);
+  }
 };
 
 const updateChatMetadata = async (
-	chatId: Id<"chat">,
-	modelId: string,
-	provider: string,
-	sessionToken: string,
+  chatId: Id<"chat">,
+  modelId: string,
+  provider: string,
+  sessionToken: string,
 ) => {
-	try {
-		await convexServer.mutation(api.functions.chat.updateChat, {
-			chatId,
-			model: modelId,
-			provider,
-			sessionToken,
-		});
-	} catch (err) {
-		logger.warn(`Failed to update chat model metadata: ${err}`);
-	}
+  try {
+    await convexServer.mutation(api.functions.chat.updateChat, {
+      chatId,
+      model: modelId,
+      provider,
+      sessionToken,
+    });
+  } catch (err) {
+    logger.warn(`Failed to update chat model metadata: ${err}`);
+  }
 };
 
 export const ServerRoute = createServerFileRoute("/api/chat").methods({
-	GET: ({ request: _ }) => {
-		return new Response("What do you think chat?");
-	},
-	POST: async ({ request }) => {
-		const session = await auth.api.getSession({
-			headers: getWebRequest()?.headers ?? new Headers(),
-		});
+  GET: ({ request: _ }) => {
+    return new Response("What do you think chat?");
+  },
+  POST: async ({ request }) => {
+    const session = await auth.api.getSession({
+      headers: getWebRequest()?.headers ?? new Headers(),
+    });
 
-		if (!session) {
-			return new Response("Unauthorized", { status: 401 });
-		}
+    if (!session) {
+      return new Response("Unauthorized", { status: 401 });
+    }
 
-		const sessionToken = session.session.token;
-		const {
-			messages,
-			chatId,
-			modelId: requestedModelId,
-			search = false,
-			reasoningEffort,
-			attachments = [],
-		} = await request.json();
+    const sessionToken = session.session.token;
+    const {
+      messages,
+      chatId,
+      modelId: requestedModelId,
+      search = false,
+      reasoningEffort,
+      attachments = [],
+    } = await request.json();
 
-		const lastMessage = messages[messages.length - 1];
-		let transformedMessages = messages;
+    const lastMessage = messages[messages.length - 1];
+    let transformedMessages = messages;
 
-		if (lastMessage.role === "user") {
-			const userMessageId = await convexServer.mutation(
-				api.functions.message.createUserMessage,
-				{
-					chatId,
-					content: lastMessage.content,
-					sessionToken,
-				},
-			);
+    if (lastMessage.role === "user") {
+      const userMessageId = await convexServer.mutation(
+        api.functions.message.createUserMessage,
+        {
+          chatId,
+          content: lastMessage.content,
+          sessionToken,
+        },
+      );
 
-			// Transform messages with attachment content for AI model
-			if (attachments.length > 0) {
-				const { existingAttachmentIds, newAttachments } =
-					separateAttachments(attachments);
+      // Transform messages with attachment content for AI model
+      if (attachments.length > 0) {
+        const { existingAttachmentIds, newAttachments } =
+          separateAttachments(attachments);
 
-				// Fetch existing attachments data if any
-				const existingAttachmentsData = await fetchExistingAttachments(
-					existingAttachmentIds,
-					sessionToken,
-				);
+        // Fetch existing attachments data if any
+        const existingAttachmentsData = await fetchExistingAttachments(
+          existingAttachmentIds,
+          sessionToken,
+        );
 
-				// Combine all attachments for message transformation
-				const allAttachmentsForAI = processAttachmentsForAI(
-					existingAttachmentsData,
-					newAttachments,
-				);
+        // Combine all attachments for message transformation
+        const allAttachmentsForAI = processAttachmentsForAI(
+          existingAttachmentsData,
+          newAttachments,
+        );
 
-				// Transform last message to include attachments for AI
-				if (allAttachmentsForAI.length > 0) {
-					const messageContent = transformMessageWithAttachments(
-						lastMessage,
-						allAttachmentsForAI,
-					);
+        // Transform last message to include attachments for AI
+        if (allAttachmentsForAI.length > 0) {
+          const messageContent = transformMessageWithAttachments(
+            lastMessage,
+            allAttachmentsForAI,
+          );
 
-					// Update transformedMessages with multimodal content
-					transformedMessages = [
-						...messages.slice(0, -1),
-						{
-							...lastMessage,
-							content: messageContent,
-						},
-					];
-				}
+          // Update transformedMessages with multimodal content
+          transformedMessages = [
+            ...messages.slice(0, -1),
+            {
+              ...lastMessage,
+              content: messageContent,
+            },
+          ];
+        }
 
-				// Process attachments in background (fire-and-forget) - only for new attachments
-				if (newAttachments.length > 0 && userMessageId) {
-					waitUntil(
-						processAttachmentsInBackground(
-							newAttachments,
-							userMessageId,
-							existingAttachmentIds,
-							sessionToken,
-						),
-					);
-				}
-			}
-		}
+        // Process attachments in background (fire-and-forget) - only for new attachments
+        if (newAttachments.length > 0 && userMessageId) {
+          waitUntil(
+            processAttachmentsInBackground(
+              newAttachments,
+              userMessageId,
+              existingAttachmentIds,
+              sessionToken,
+            ),
+          );
+        }
+      }
+    }
 
-		const selectedModel = requestedModelId
-			? getModelById(requestedModelId)
-			: getDefaultModel();
-		if (!selectedModel) {
-			return new Response("Invalid model selection", { status: 400 });
-		}
+    const selectedModel = requestedModelId
+      ? getModelById(requestedModelId)
+      : getDefaultModel();
+    if (!selectedModel) {
+      return new Response("Invalid model selection", { status: 400 });
+    }
 
-		const { provider, modelId } = selectedModel;
+    const { provider, modelId } = selectedModel;
 
-		logger.info(
-			`Starting chat stream: ${chatId} (model: ${selectedModel.name}, search: ${search}${reasoningEffort ? `, reasoning: ${reasoningEffort}` : ""})`,
-		);
+    logger.info(
+      `Starting chat stream: ${chatId} (model: ${selectedModel.name}, search: ${search}${reasoningEffort ? `, reasoning: ${reasoningEffort}` : ""})`,
+    );
 
-		const providerOptions =
-			reasoningEffort && selectedModel.reasoningEffort
-				? { openrouter: { reasoning: { effort: reasoningEffort } } }
-				: undefined;
+    const providerOptions =
+      reasoningEffort && selectedModel.reasoningEffort
+        ? { openrouter: { reasoning: { effort: reasoningEffort } } }
+        : undefined;
 
-		const toolSet = (
-			search ? { mathEvaluation, webSearch } : { mathEvaluation }
-		) as ToolSet;
-		const maxSteps = selectedModel.reasoningEffort
-			? search
-				? 5
-				: 3
-			: search
-				? 7
-				: 5;
+    const toolSet = (
+      search ? { mathEvaluation, webSearch } : { mathEvaluation }
+    ) as ToolSet;
+    const maxSteps = selectedModel.reasoningEffort
+      ? search
+        ? 5
+        : 3
+      : search
+        ? 7
+        : 5;
 
-		try {
-			const result = streamText({
-				model: openrouter.chat(modelId),
-				system: getSystemPrompt(selectedModel, session.user.name, search),
-				messages: transformedMessages,
-				abortSignal: request.signal,
-				...(providerOptions ? { providerOptions } : {}),
-				tools: toolSet,
-				maxSteps,
-			});
+    try {
+      const result = streamText({
+        model: openrouter.chat(modelId),
+        system: getSystemPrompt(selectedModel, session.user.name, search),
+        messages: transformedMessages,
+        abortSignal: request.signal,
+        ...(providerOptions ? { providerOptions } : {}),
+        tools: toolSet,
+        maxSteps,
+      });
 
-			const messageId = await createAiMessage({
-				chatId,
-				sessionToken,
-				provider,
-				model: selectedModel.name,
-			});
+      const messageId = await createAiMessage({
+        chatId,
+        sessionToken,
+        provider,
+        model: selectedModel.name,
+      });
 
-			if (!messageId) {
-				return new Response("Failed to create AI message", {
-					status: API_CONSTANTS.STATUS_CODES.INTERNAL_SERVER_ERROR,
-				});
-			}
+      if (!messageId) {
+        return new Response("Failed to create AI message", {
+          status: API_CONSTANTS.STATUS_CODES.INTERNAL_SERVER_ERROR,
+        });
+      }
 
-			waitUntil(
-				updateChatMetadata(
-					chatId,
-					selectedModel.modelId,
-					provider,
-					sessionToken,
-				),
-			);
+      waitUntil(
+        updateChatMetadata(
+          chatId,
+          selectedModel.modelId,
+          provider,
+          sessionToken,
+        ),
+      );
 
-			// Start streaming processing in the background
-			waitUntil(
-				processStreamingResponse(
-					result,
-					messageId,
-					sessionToken,
-					reasoningEffort,
-					selectedModel,
-					provider,
-					chatId,
-				),
-			);
+      // Start streaming processing in the background
+      waitUntil(
+        processStreamingResponse(
+          result,
+          messageId,
+          sessionToken,
+          reasoningEffort,
+          selectedModel,
+          provider,
+          chatId,
+        ),
+      );
 
-			return result.toDataStreamResponse({
-				sendReasoning: true,
-			});
-		} catch (error) {
-			logger.error(`Chat streaming failed for ${chatId}: ${error}`);
-			return new Response("Error streaming chat", {
-				status: API_CONSTANTS.STATUS_CODES.INTERNAL_SERVER_ERROR,
-			});
-		}
-	},
+      return result.toDataStreamResponse({
+        sendReasoning: true,
+      });
+    } catch (error) {
+      logger.error(`Chat streaming failed for ${chatId}: ${error}`);
+      return new Response("Error streaming chat", {
+        status: API_CONSTANTS.STATUS_CODES.INTERNAL_SERVER_ERROR,
+      });
+    }
+  },
 });
 
 // Streaming response processing
 const processStreamingResponse = async (
-	// biome-ignore lint/suspicious/noExplicitAny: no easy way to type this
-	result: any,
-	messageId: MessageId,
-	sessionToken: string,
-	reasoningEffort: string | undefined,
-	selectedModel: ReturnType<typeof getModelById>,
-	provider: string,
-	_chatId: Id<"chat">,
+  // biome-ignore lint/suspicious/noExplicitAny: no easy way to type this
+  result: any,
+  messageId: MessageId,
+  sessionToken: string,
+  reasoningEffort: string | undefined,
+  selectedModel: ReturnType<typeof getModelById>,
+  provider: string,
+  _chatId: Id<"chat">,
 ) => {
-	const state: StreamingState = {
-		contentBuffer: "",
-		reasoningBuffer: {
-			text: "",
-			details: [],
-			duration: 0,
-			reasoningEffort,
-		},
-		lastReasoningDelta: "",
-		lastReasoningUpdate: 0,
-		usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
-		isAborted: false,
-		lastUpdate: 0,
-		finishReason: undefined,
-		hasToolErrors: false,
-	};
+  const state: StreamingState = {
+    contentBuffer: "",
+    reasoningBuffer: {
+      text: "",
+      details: [],
+      duration: 0,
+      reasoningEffort,
+    },
+    lastReasoningDelta: "",
+    lastReasoningUpdate: 0,
+    usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    isAborted: false,
+    lastUpdate: 0,
+    finishReason: undefined,
+    hasToolErrors: false,
+  };
 
-	const processReasoning = (textDelta: string) => {
-		const cleanedDelta = textDelta?.replace(/\0/g, "") || "";
-		state.reasoningBuffer.text = cleanedDelta;
-		const steps = splitReasoningSteps(cleanedDelta);
-		state.reasoningBuffer.details = steps.map((step) => ({ text: step }));
-		state.lastReasoningDelta = cleanedDelta;
-		state.lastReasoningUpdate = Date.now();
-	};
+  const processReasoning = (textDelta: string) => {
+    const cleanedDelta = textDelta?.replace(/\0/g, "") || "";
+    state.reasoningBuffer.text = cleanedDelta;
+    const steps = splitReasoningSteps(cleanedDelta);
+    state.reasoningBuffer.details = steps.map((step) => ({ text: step }));
+    state.lastReasoningDelta = cleanedDelta;
+    state.lastReasoningUpdate = Date.now();
+  };
 
-	const shouldUpdateMessage = () => {
-		const now = Date.now();
-		return (
-			now - state.lastUpdate > UI_CONSTANTS.POLLING_INTERVALS.UPDATE_INTERVAL ||
-			now - state.lastReasoningUpdate >
-				UI_CONSTANTS.POLLING_INTERVALS.SLOW_UPDATE
-		);
-	};
+  const shouldUpdateMessage = () => {
+    const now = Date.now();
+    return (
+      now - state.lastUpdate > UI_CONSTANTS.POLLING_INTERVALS.UPDATE_INTERVAL ||
+      now - state.lastReasoningUpdate >
+        UI_CONSTANTS.POLLING_INTERVALS.SLOW_UPDATE
+    );
+  };
 
-	const updateMessage = async (status = MessageStatus.STREAMING) => {
-		if (!shouldUpdateMessage() && status === MessageStatus.STREAMING) return;
+  const updateMessage = async (status = MessageStatus.STREAMING) => {
+    if (!shouldUpdateMessage() && status === MessageStatus.STREAMING) return;
 
-		const currentReasoning =
-			state.reasoningBuffer.details.length > 0
-				? state.reasoningBuffer
-				: undefined;
-		const currentUsage = state.usage.totalTokens > 0 ? state.usage : undefined;
+    const currentReasoning =
+      state.reasoningBuffer.details.length > 0
+        ? state.reasoningBuffer
+        : undefined;
+    const currentUsage = state.usage.totalTokens > 0 ? state.usage : undefined;
 
-		await updateAiMessage({
-			messageId,
-			content: state.contentBuffer,
-			reasoning: currentReasoning,
-			status,
-			model: selectedModel?.name,
-			provider,
-			usage: currentUsage,
-			sessionToken,
-		});
+    await updateAiMessage({
+      messageId,
+      content: state.contentBuffer,
+      reasoning: currentReasoning,
+      status,
+      model: selectedModel?.name,
+      provider,
+      usage: currentUsage,
+      sessionToken,
+    });
 
-		state.lastUpdate = Date.now();
-	};
+    state.lastUpdate = Date.now();
+  };
 
-	try {
-		for await (const chunk of result.fullStream) {
-			switch (chunk.type) {
-				case "text-delta":
-					state.contentBuffer += chunk.textDelta;
-					await updateMessage();
-					break;
+  try {
+    for await (const chunk of result.fullStream) {
+      switch (chunk.type) {
+        case "text-delta":
+          state.contentBuffer += chunk.textDelta;
+          await updateMessage();
+          break;
 
-				case "reasoning":
-					processReasoning(chunk.textDelta);
-					await updateMessage();
-					break;
+        case "reasoning":
+          processReasoning(chunk.textDelta);
+          await updateMessage();
+          break;
 
-				case "tool-call":
-					logger.info(`Tool call: ${chunk.toolName}`);
-					break;
+        case "tool-call":
+          logger.info(`Tool call: ${chunk.toolName}`);
+          break;
 
-				case "tool-result":
-					logger.info(`Tool result: ${chunk.toolName}`);
-					if (
-						chunk.result &&
-						typeof chunk.result === "object" &&
-						"error" in chunk.result
-					) {
-						logger.warn(
-							`Tool execution error in ${chunk.toolName}: ${chunk.result.error}`,
-						);
-						state.hasToolErrors = true;
-					}
-					break;
+        case "tool-result":
+          logger.info(`Tool result: ${chunk.toolName}`);
+          if (
+            chunk.result &&
+            typeof chunk.result === "object" &&
+            "error" in chunk.result
+          ) {
+            logger.warn(
+              `Tool execution error in ${chunk.toolName}: ${chunk.result.error}`,
+            );
+            state.hasToolErrors = true;
+          }
+          break;
 
-				case "error": {
-					const errorString = String(chunk.error);
-					if (errorString.includes("AI_ToolExecutionError")) {
-						logger.warn(`Tool execution error: ${errorString}`);
-						state.hasToolErrors = true;
-					} else {
-						logger.error(`Streaming error: ${chunk.error}`);
-						state.isAborted = true;
-					}
-					break;
-				}
+        case "error": {
+          const errorString = String(chunk.error);
+          if (errorString.includes("AI_ToolExecutionError")) {
+            logger.warn(`Tool execution error: ${errorString}`);
+            state.hasToolErrors = true;
+          } else {
+            logger.error(`Streaming error: ${chunk.error}`);
+            state.isAborted = true;
+          }
+          break;
+        }
 
-				case "finish":
-					state.finishReason = chunk.finishReason;
-					logger.info(`Streaming finished: ${chunk.finishReason}`);
+        case "finish":
+          state.finishReason = chunk.finishReason;
+          logger.info(`Streaming finished: ${chunk.finishReason}`);
 
-					if (chunk.finishReason === "stop" && state.hasToolErrors) {
-						logger.warn(
-							"Model stopped early likely due to tool execution errors - completing message gracefully",
-						);
-					} else if (chunk.finishReason === "length") {
-						logger.warn(
-							"Model stopped due to length limit - message may be truncated",
-						);
-					} else if (chunk.finishReason === "tool-calls") {
-						logger.info("Model finished after tool calls");
-					}
-					break;
+          if (chunk.finishReason === "stop" && state.hasToolErrors) {
+            logger.warn(
+              "Model stopped early likely due to tool execution errors - completing message gracefully",
+            );
+          } else if (chunk.finishReason === "length") {
+            logger.warn(
+              "Model stopped due to length limit - message may be truncated",
+            );
+          } else if (chunk.finishReason === "tool-calls") {
+            logger.info("Model finished after tool calls");
+          }
+          break;
 
-				default:
-					break;
-			}
-		}
+        default:
+          break;
+      }
+    }
 
-		if (!state.isAborted) {
-			const messageStatus = await getMessageStatus({ messageId, sessionToken });
+    if (!state.isAborted) {
+      const messageStatus = await getMessageStatus({ messageId, sessionToken });
 
-			let finalStatus = MessageStatus.COMPLETED;
+      let finalStatus = MessageStatus.COMPLETED;
 
-			if (
-				(state.finishReason === "stop" ||
-					state.finishReason === "tool-calls") &&
-				state.hasToolErrors
-			) {
-				if (state.contentBuffer.trim().length === 0) {
-					state.contentBuffer =
-						"I encountered an error while trying to evaluate that mathematical expression. Please check the function name or expression format and try again.";
-					logger.info(
-						`Added fallback content for empty message with tool errors: ${messageId}`,
-					);
-				}
-				logger.info(
-					`Completing message gracefully despite early stop due to tool errors: ${messageId}`,
-				);
-				finalStatus = MessageStatus.COMPLETED;
-			} else if (state.finishReason === "length") {
-				logger.info(
-					`Message completed but may be truncated due to length: ${messageId}`,
-				);
-				finalStatus = MessageStatus.COMPLETED;
-			}
+      if (
+        (state.finishReason === "stop" ||
+          state.finishReason === "tool-calls") &&
+        state.hasToolErrors
+      ) {
+        if (state.contentBuffer.trim().length === 0) {
+          state.contentBuffer =
+            "I encountered an error while trying to evaluate that mathematical expression. Please check the function name or expression format and try again.";
+          logger.info(
+            `Added fallback content for empty message with tool errors: ${messageId}`,
+          );
+        }
+        logger.info(
+          `Completing message gracefully despite early stop due to tool errors: ${messageId}`,
+        );
+        finalStatus = MessageStatus.COMPLETED;
+      } else if (state.finishReason === "length") {
+        logger.info(
+          `Message completed but may be truncated due to length: ${messageId}`,
+        );
+        finalStatus = MessageStatus.COMPLETED;
+      }
 
-			if (messageStatus === MessageStatus.STREAMING || state.hasToolErrors) {
-				await updateMessage(finalStatus);
-				logger.info(
-					`Message completed with status ${finalStatus}: ${messageId}`,
-				);
-			} else {
-				logger.warn(
-					`Message not in streaming status and no tool errors, current status: ${messageStatus}`,
-				);
-			}
-		} else {
-			logger.warn("Stream was aborted, not processing completion");
-		}
-	} catch (error) {
-		logger.error(`Streaming processing failed: ${error}`);
-		state.isAborted = true;
-		const messageStatus = await getMessageStatus({ messageId, sessionToken });
-		if (messageStatus === MessageStatus.STREAMING) {
-			await updateMessage(MessageStatus.FAILED);
-		}
-	}
+      if (messageStatus === MessageStatus.STREAMING || state.hasToolErrors) {
+        await updateMessage(finalStatus);
+        logger.info(
+          `Message completed with status ${finalStatus}: ${messageId}`,
+        );
+      } else {
+        logger.warn(
+          `Message not in streaming status and no tool errors, current status: ${messageStatus}`,
+        );
+      }
+    } else {
+      logger.warn("Stream was aborted, not processing completion");
+    }
+  } catch (error) {
+    logger.error(`Streaming processing failed: ${error}`);
+    state.isAborted = true;
+    const messageStatus = await getMessageStatus({ messageId, sessionToken });
+    if (messageStatus === MessageStatus.STREAMING) {
+      await updateMessage(MessageStatus.FAILED);
+    }
+  }
 };


### PR DESCRIPTION
## Summary
- Implemented comprehensive message editing functionality for user messages
- Users can now edit their past messages, which automatically triggers AI regeneration
- Follows the same UX patterns as Claude and ChatGPT

## Features Implemented

### UI/UX
- Added edit icon (pencil) next to copy button for user messages
- Edit mode with textarea for inline editing
- Cancel and Save buttons positioned at bottom right of message
- Keyboard shortcuts: Ctrl/Cmd+Enter to save, Escape to cancel
- Real-time updates without requiring page refresh

### Backend Logic
- Created `editUserMessage` Convex function that:
  - Updates message content in place
  - Automatically deletes all subsequent messages
  - Preserves message history for version tracking
- Added `regenerate` function for AI response generation
- Implemented `isRegeneration` flag to prevent duplicate user messages

### Technical Improvements
- Fixed issue where regeneration used old cached content instead of edited content
- Enabled real-time polling for immediate UI updates after editing
- Added proper delays for database propagation
- Prevented creation of empty user messages during regeneration

## Test Plan
- [x] Edit a user message and verify content updates
- [x] Confirm subsequent messages are deleted
- [x] Verify AI regenerates response with edited content
- [x] Test keyboard shortcuts (Ctrl/Cmd+Enter, Escape)
- [x] Ensure no duplicate user messages are created
- [x] Verify real-time updates work without refresh

🤖 Generated with [Claude Code](https://claude.ai/code)