### PR TITLE
Fix: Require authentication before showing chat interface

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -58,27 +58,31 @@ export function AppSidebar() {
         </div>
       </SidebarHeader>
       <SidebarContent className="no-scrollbar">
-        <SidebarGroup>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigate({ to: "/" });
-                  }}
-                  tooltip="New Chat"
-                  className="cursor-pointer bg-primary text-primary-foreground hover:bg-primary/80 hover:text-primary-foreground"
-                >
-                  <Plus className="h-4 w-4" />
-                  <span>New Chat</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-        <Separator className="group-data-[collapsible=icon]:hidden" />
-        {pinned.length > 0 && (
+        {session?.user && (
+          <>
+            <SidebarGroup>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigate({ to: "/" });
+                      }}
+                      tooltip="New Chat"
+                      className="cursor-pointer bg-primary text-primary-foreground hover:bg-primary/80 hover:text-primary-foreground"
+                    >
+                      <Plus className="h-4 w-4" />
+                      <span>New Chat</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+            <Separator className="group-data-[collapsible=icon]:hidden" />
+          </>
+        )}
+        {session?.user && pinned.length > 0 && (
           <SidebarGroup className="group-data-[collapsible=icon]:hidden">
             <SidebarGroupLabel>Pinned</SidebarGroupLabel>
             <SidebarGroupContent>
@@ -157,77 +161,85 @@ export function AppSidebar() {
             </SidebarGroupContent>
           </SidebarGroup>
         )}
-        <SidebarGroup className="group-data-[collapsible=icon]:hidden">
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {unpinned.map((chat) => (
-                <SidebarMenuItem key={chat._id} className="group/item relative">
-                  <SidebarMenuButton
-                    asChild
-                    isActive={"chatId" in params && params.chatId === chat._id}
-                    tooltip={chat.title}
-                    className="group-hover/item:bg-sidebar-accent"
+        {session?.user && (
+          <SidebarGroup className="group-data-[collapsible=icon]:hidden">
+            <SidebarGroupLabel>Chats</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {unpinned.map((chat) => (
+                  <SidebarMenuItem
+                    key={chat._id}
+                    className="group/item relative"
                   >
-                    <Link
-                      key={chat._id}
-                      to="/chat/$chatId"
-                      params={{ chatId: chat._id }}
+                    <SidebarMenuButton
+                      asChild
+                      isActive={
+                        "chatId" in params && params.chatId === chat._id
+                      }
+                      tooltip={chat.title}
+                      className="group-hover/item:bg-sidebar-accent"
                     >
-                      <span>{chat.title}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                  <div className="absolute top-1.5 right-1 z-10 hidden flex-row items-center gap-1 group-hover/item:flex group-hover/item:bg-sidebar-accent group-data-[collapsible=icon]:hidden">
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <SidebarMenuAction
-                          showOnHover
-                          onClick={async (e) => {
-                            e.stopPropagation();
-                            e.preventDefault();
-                            await pinChat({
-                              chatId: chat._id,
-                              sessionToken: session?.session.token ?? "",
-                            });
-                          }}
-                          className="static hover:cursor-pointer hover:text-blue-500"
-                        >
-                          <Pin className="size-4" />
-                        </SidebarMenuAction>
-                      </TooltipTrigger>
-                      <TooltipContent hideWhenDetached>
-                        <p>Pin</p>
-                      </TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <SidebarMenuAction
-                          showOnHover
-                          onClick={async (e) => {
-                            e.stopPropagation();
-                            e.preventDefault();
-                            await deleteChat({
-                              chatId: chat._id,
-                              sessionToken: session?.session.token ?? "",
-                            });
-                            if (params.chatId === chat._id) {
-                              navigate({ to: "/" });
-                            }
-                          }}
-                          className="static hover:cursor-pointer hover:text-destructive"
-                        >
-                          <X className="size-4" />
-                        </SidebarMenuAction>
-                      </TooltipTrigger>
-                      <TooltipContent hideWhenDetached>
-                        <p>Delete</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
+                      <Link
+                        key={chat._id}
+                        to="/chat/$chatId"
+                        params={{ chatId: chat._id }}
+                      >
+                        <span>{chat.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                    <div className="absolute top-1.5 right-1 z-10 hidden flex-row items-center gap-1 group-hover/item:flex group-hover/item:bg-sidebar-accent group-data-[collapsible=icon]:hidden">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <SidebarMenuAction
+                            showOnHover
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                              await pinChat({
+                                chatId: chat._id,
+                                sessionToken: session?.session.token ?? "",
+                              });
+                            }}
+                            className="static hover:cursor-pointer hover:text-blue-500"
+                          >
+                            <Pin className="size-4" />
+                          </SidebarMenuAction>
+                        </TooltipTrigger>
+                        <TooltipContent hideWhenDetached>
+                          <p>Pin</p>
+                        </TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <SidebarMenuAction
+                            showOnHover
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                              await deleteChat({
+                                chatId: chat._id,
+                                sessionToken: session?.session.token ?? "",
+                              });
+                              if (params.chatId === chat._id) {
+                                navigate({ to: "/" });
+                              }
+                            }}
+                            className="static hover:cursor-pointer hover:text-destructive"
+                          >
+                            <X className="size-4" />
+                          </SidebarMenuAction>
+                        </TooltipTrigger>
+                        <TooltipContent hideWhenDetached>
+                          <p>Delete</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
       </SidebarContent>
       <SidebarFooter>
         <ProfileCard />

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -1,146 +1,223 @@
 import { useParams } from "@tanstack/react-router";
-import { ArrowDown } from "lucide-react";
+import { ArrowDown, LogIn } from "lucide-react";
 import { AnimatePresence } from "motion/react";
-import { useEffect } from "react";
+import { useEffect, useState, useTransition } from "react";
+import { CaptchaWidget } from "~/components/auth/captcha-widget";
 import { ChatInput } from "~/components/chat/chat-input";
 import { MemoizedMessage, Message } from "~/components/chat/message";
 import { ChatStatus, MessageStatus } from "~/components/chat/types";
+import { DomainLogo } from "~/components/domains";
 import {
-	ChatErrorBoundary,
-	MessageErrorBoundary,
+  ChatErrorBoundary,
+  MessageErrorBoundary,
 } from "~/components/error-boundary";
 import { Button } from "~/components/ui/button";
 import { useChat } from "~/hooks/use-chat";
 import { useChatScroll } from "~/hooks/use-chat-scroll";
 import { useChatsList } from "~/hooks/use-chats-list";
 import { useFirstMessage } from "~/hooks/use-first-message";
-import { authClient } from "~/lib/auth/client";
+import { authClient, getClientIP } from "~/lib/auth/client";
+import { logger } from "~/lib/logger";
 import { models } from "~/lib/models";
 
 export function ChatView() {
-	const { data: session } = authClient.useSession();
-	const params = useParams({ strict: false }) as { chatId?: string };
-	const chatId = params?.chatId;
-	const chatsList = useChatsList();
-	const {
-		messages,
-		status,
-		append,
-		regenerate,
-		stop,
-		setSelectedModelId,
-		isLoadingMessages,
-	} = useChat(chatId);
+  const { data: session, isPending: isSessionPending } =
+    authClient.useSession();
+  const [isPending, startTransition] = useTransition();
+  const [captchaToken, setCaptchaToken] = useState<string>("");
+  const params = useParams({ strict: false }) as { chatId?: string };
+  const chatId = params?.chatId;
+  const chatsList = useChatsList();
+  const {
+    messages,
+    status,
+    append,
+    regenerate,
+    stop,
+    setSelectedModelId,
+    isLoadingMessages,
+  } = useChat(chatId);
 
-	const { messagesContainerRef, bottomRef, showScrollButton, scrollToBottom } =
-		useChatScroll();
+  const { messagesContainerRef, bottomRef, showScrollButton, scrollToBottom } =
+    useChatScroll();
 
-	useEffect(() => {
-		if (!chatId || !chatsList.data) return;
-		const chat = (
-			chatsList.data as Array<{ _id: string; model?: string }>
-		).find((c) => c._id === chatId);
-		if (chat?.model) {
-			const model = models.find((m) => m.modelId === chat.model);
-			if (model) {
-				setSelectedModelId((prev) => (prev === model.id ? prev : model.id));
-			}
-		}
-	}, [chatId, chatsList.data, setSelectedModelId]);
+  useEffect(() => {
+    if (!chatId || !chatsList.data) return;
+    const chat = (
+      chatsList.data as Array<{ _id: string; model?: string }>
+    ).find((c) => c._id === chatId);
+    if (chat?.model) {
+      const model = models.find((m) => m.modelId === chat.model);
+      if (model) {
+        setSelectedModelId((prev) => (prev === model.id ? prev : model.id));
+      }
+    }
+  }, [chatId, chatsList.data, setSelectedModelId]);
 
-	useEffect(() => {
-		if (messages.length > 0 && messagesContainerRef.current) {
-			messagesContainerRef.current.scrollTop =
-				messagesContainerRef.current.scrollHeight;
-		}
-	}, [messages.length, messagesContainerRef]);
+  useEffect(() => {
+    if (messages.length > 0 && messagesContainerRef.current) {
+      messagesContainerRef.current.scrollTop =
+        messagesContainerRef.current.scrollHeight;
+    }
+  }, [messages.length, messagesContainerRef]);
 
-	useFirstMessage({
-		chatId,
-		sessionToken: session?.session.token,
-		append,
-	});
+  useFirstMessage({
+    chatId,
+    sessionToken: session?.session.token,
+    append,
+  });
 
-	const isEmpty = !chatId || (messages.length === 0 && !isLoadingMessages);
+  const handleGoogleLogin = async () => {
+    startTransition(async () => {
+      const ipAddress = await getClientIP();
+      try {
+        const { error } = await authClient.signIn.social({
+          provider: "google",
+          callbackURL: "/",
+          fetchOptions: {
+            headers: {
+              "x-captcha-response": captchaToken,
+              "x-captcha-user-remote-ip": ipAddress ?? "",
+            },
+          },
+        });
+        if (error) {
+          logger.error(
+            `Google OAuth sign-in failed: ${error.message || "Unknown error"}`,
+          );
+          return;
+        }
+      } catch (error: unknown) {
+        logger.error(
+          `Google OAuth request failed: ${error instanceof Error ? error.message : "Network or configuration error"}`,
+        );
+        return;
+      }
+    });
+  };
 
-	return (
-		<div className="relative flex h-dvh flex-col overflow-hidden bg-background md:h-screen">
-			<div
-				ref={messagesContainerRef}
-				className="scrollbar scrollbar-thumb-border scrollbar-track-transparent hover:scrollbar-thumb-border/80 scrollbar-w-2 ml-4 min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 pb-2"
-			>
-				{isEmpty ? (
-					<div className="flex h-full items-center justify-center text-foreground">
-						<h1 className="text-2xl">Where should we begin?</h1>
-					</div>
-				) : (
-					<div className="mx-auto max-w-[752px] space-y-3 pt-5">
-						<AnimatePresence initial={false}>
-							{messages.map((m, index) => {
-								const handleMessageEdit = (editedContent: string) => {
-									// Only regenerate if this is a user message
-									if (m.role === "user") {
-										// Trigger AI regeneration from the edited message with the new content
-										regenerate(m._id, editedContent);
-									}
-								};
+  const handleCaptchaSuccess = (token: string) => {
+    setCaptchaToken(token);
+  };
 
-								if (
-									status === ChatStatus.STREAMING &&
-									index === messages.length - 1 &&
-									m.status !== MessageStatus.COMPLETED
-								)
-									return (
-										<MessageErrorBoundary key={m._id}>
-											<Message
-												data={m}
-												user={session?.user}
-												onMessageEdit={handleMessageEdit}
-											/>
-										</MessageErrorBoundary>
-									);
+  const handleCaptchaError = (error: string) => {
+    logger.error(`CAPTCHA validation failed: ${error}`);
+  };
 
-								return (
-									<MessageErrorBoundary key={m._id}>
-										<MemoizedMessage
-											data={m}
-											user={session?.user}
-											onMessageEdit={handleMessageEdit}
-										/>
-									</MessageErrorBoundary>
-								);
-							})}
-						</AnimatePresence>
-						<div ref={bottomRef} />
-					</div>
-				)}
-			</div>
+  const isEmpty = !chatId || (messages.length === 0 && !isLoadingMessages);
 
-			<div className="relative z-10 shrink-0">
-				<div className="relative bg-gradient-to-t from-background via-background to-transparent px-4 [padding-bottom:calc(1rem+env(safe-area-inset-bottom))]">
-					<div className="-top-12 -translate-x-1/2 absolute left-1/2 z-20 transform">
-						<Button
-							variant="secondary"
-							size="icon"
-							className={`transition-all duration-300 ${showScrollButton ? "opacity-100" : "pointer-events-none opacity-0"} shadow-lg hover:bg-primary hover:text-primary-foreground`}
-							onClick={() => scrollToBottom()}
-						>
-							<ArrowDown className="size-4" />
-						</Button>
-					</div>
-					<ChatErrorBoundary>
-						<ChatInput
-							chatId={chatId}
-							sessionToken={session?.session.token ?? "skip"}
-							disabled={status === ChatStatus.STREAMING}
-							addUserMessage={(message, attachments) =>
-								append({ content: message, attachments })
-							}
-							onStop={stop}
-						/>
-					</ChatErrorBoundary>
-				</div>
-			</div>
-		</div>
-	);
+  if (!session?.user && !isSessionPending) {
+    return (
+      <div className="relative flex h-dvh flex-col overflow-hidden bg-background md:h-screen">
+        <div className="flex h-full items-center justify-center p-4">
+          <div className="flex max-w-md flex-col items-center gap-6 text-center">
+            <div className="rounded-full bg-primary/10 p-4">
+              <LogIn className="h-8 w-8 text-primary" />
+            </div>
+            <div className="space-y-2">
+              <h1 className="font-semibold text-2xl">Sign in to OpenYap</h1>
+              <p className="text-muted-foreground">
+                Sign in with your Google account to start yapping
+              </p>
+            </div>
+            <Button
+              size="lg"
+              variant="default"
+              onClick={handleGoogleLogin}
+              disabled={isPending}
+              className="flex w-full items-center gap-3"
+            >
+              <DomainLogo domain="google.com" config={{ type: "symbol" }} />
+              <span>Continue with Google</span>
+            </Button>
+            <CaptchaWidget
+              onSuccess={handleCaptchaSuccess}
+              onError={handleCaptchaError}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex h-dvh flex-col overflow-hidden bg-background md:h-screen">
+      <div
+        ref={messagesContainerRef}
+        className="scrollbar scrollbar-thumb-border scrollbar-track-transparent hover:scrollbar-thumb-border/80 scrollbar-w-2 ml-4 min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 pb-2"
+      >
+        {isEmpty ? (
+          <div className="flex h-full items-center justify-center text-foreground">
+            <h1 className="text-2xl">Where should we begin?</h1>
+          </div>
+        ) : (
+          <div className="mx-auto max-w-[752px] space-y-3 pt-5">
+            <AnimatePresence initial={false}>
+              {messages.map((m, index) => {
+                const handleMessageEdit = (editedContent: string) => {
+                  // Only regenerate if this is a user message
+                  if (m.role === "user") {
+                    // Trigger AI regeneration from the edited message with the new content
+                    regenerate(m._id, editedContent);
+                  }
+                };
+
+                if (
+                  status === ChatStatus.STREAMING &&
+                  index === messages.length - 1 &&
+                  m.status !== MessageStatus.COMPLETED
+                )
+                  return (
+                    <MessageErrorBoundary key={m._id}>
+                      <Message
+                        data={m}
+                        user={session?.user}
+                        onMessageEdit={handleMessageEdit}
+                      />
+                    </MessageErrorBoundary>
+                  );
+
+                return (
+                  <MessageErrorBoundary key={m._id}>
+                    <MemoizedMessage
+                      data={m}
+                      user={session?.user}
+                      onMessageEdit={handleMessageEdit}
+                    />
+                  </MessageErrorBoundary>
+                );
+              })}
+            </AnimatePresence>
+            <div ref={bottomRef} />
+          </div>
+        )}
+      </div>
+
+      <div className="relative z-10 shrink-0">
+        <div className="relative bg-gradient-to-t from-background via-background to-transparent px-4 [padding-bottom:calc(1rem+env(safe-area-inset-bottom))]">
+          <div className="-top-12 -translate-x-1/2 absolute left-1/2 z-20 transform">
+            <Button
+              variant="secondary"
+              size="icon"
+              className={`transition-all duration-300 ${showScrollButton ? "opacity-100" : "pointer-events-none opacity-0"} shadow-lg hover:bg-primary hover:text-primary-foreground`}
+              onClick={() => scrollToBottom()}
+            >
+              <ArrowDown className="size-4" />
+            </Button>
+          </div>
+          <ChatErrorBoundary>
+            <ChatInput
+              chatId={chatId}
+              sessionToken={session?.session.token ?? "skip"}
+              disabled={status === ChatStatus.STREAMING}
+              addUserMessage={(message, attachments) =>
+                append({ content: message, attachments })
+              }
+              onStop={stop}
+            />
+          </ChatErrorBoundary>
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Adds clear authentication requirement for chat functionality
- Prevents confusing UX where unauthenticated users could see chat UI but couldn't use it
- Improves overall user onboarding experience

## Changes
### ChatView Component (`chat-view.tsx`)
- Added loading state while checking authentication status
- Created dedicated sign-in screen for unauthenticated users with:
  - Clear messaging about signing in requirement
  - Google OAuth sign-in button with proper branding
  - CAPTCHA integration for security
  - Terms of service notice
- Chat interface now only renders for authenticated users

### Sidebar Component (`app-sidebar.tsx`)
- "New Chat" button only visible to authenticated users
- Chat lists (pinned and unpinned) hidden from unauthenticated users
- Profile card remains visible and shows "Continue with Google" for non-authenticated users

## Before/After
**Before:** Unauthenticated users could see the chat interface and attempt to send messages, resulting in backend errors or silent failures

**After:** Unauthenticated users immediately see a clear, professional sign-in prompt explaining they need to authenticate to use the chat feature

## Test Plan
- [x] Verified unauthenticated users see sign-in prompt on homepage
- [x] Verified sidebar hides chat-related UI for unauthenticated users
- [x] Verified authenticated users can still access all chat functionality
- [x] Tested Google OAuth sign-in flow
- [x] Ran Biome linting and formatting (`pnpm check:fix`)